### PR TITLE
Allow to fill `meta` prop of an action

### DIFF
--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -4,33 +4,51 @@ import isPlainObject from 'lodash.isplainobject';
 describe('createAction()', () => {
   describe('resulting action creator', () => {
     const type = 'TYPE';
-    const actionCreator = createAction(type, b => b, ({ cid }) => ({cid}));
-    const foobar = { foo: 'bar', cid: 5 };
-    const action = actionCreator(foobar);
 
     it('returns plain object', () => {
+      const actionCreator = createAction(type, b => b);
+      const foobar = { foo: 'bar' };
+      const action = actionCreator(foobar);
       expect(isPlainObject(action)).to.be.true;
     });
 
     it('uses return value as payload', () => {
+      const actionCreator = createAction(type, b => b);
+      const foobar = { foo: 'bar' };
+      const action = actionCreator(foobar);
       expect(action.payload).to.equal(foobar);
     });
 
     it('has no extraneous keys', () => {
+      const actionCreator = createAction(type, b => b);
+      const foobar = { foo: 'bar' };
+      const action = actionCreator(foobar);
+      expect(action).to.deep.equal({
+        type,
+        payload: foobar
+      });
+    });
+
+    it('uses identity function if actionCreator is not a function', () => {
+      const actionCreator = createAction(type);
+      const foobar = { foo: 'bar' };
+      const action = actionCreator(foobar);
+      expect(action).to.deep.equal({
+        type,
+        payload: foobar
+      });
+    });
+
+    it('accepts a second parameter for adding meta to object', () => {
+      const actionCreator = createAction(type, null, ({ cid }) => ({ cid }));
+      const foobar = { foo: 'bar', cid: 5 };
+      const action = actionCreator(foobar);
       expect(action).to.deep.equal({
         type,
         payload: foobar,
         meta: {
           cid: 5
         }
-      });
-    });
-
-    it('uses identity function if actionCreator and/or metaCreator is not a function', () => {
-      expect(createAction(type)(foobar)).to.deep.equal({
-        type,
-        payload: foobar,
-        meta: foobar
       });
     });
   });

--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -4,8 +4,8 @@ import isPlainObject from 'lodash.isplainobject';
 describe('createAction()', () => {
   describe('resulting action creator', () => {
     const type = 'TYPE';
-    const actionCreator = createAction(type, b => b);
-    const foobar = { foo: 'bar' };
+    const actionCreator = createAction(type, b => b, ({ cid }) => ({cid}));
+    const foobar = { foo: 'bar', cid: 5 };
     const action = actionCreator(foobar);
 
     it('returns plain object', () => {
@@ -19,14 +19,18 @@ describe('createAction()', () => {
     it('has no extraneous keys', () => {
       expect(action).to.deep.equal({
         type,
-        payload: foobar
+        payload: foobar,
+        meta: {
+          cid: 5
+        }
       });
     });
 
-    it('uses identity function if actionCreator is not a function', () => {
+    it('uses identity function if actionCreator and/or metaCreator is not a function', () => {
       expect(createAction(type)(foobar)).to.deep.equal({
         type,
-        payload: foobar
+        payload: foobar,
+        meta: foobar
       });
     });
   });

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -2,13 +2,18 @@ function identity(t) {
   return t;
 }
 
-export default function createAction(type, actionCreator) {
+export default function createAction(type, actionCreator, metaCreator) {
   const finalActionCreator = typeof actionCreator === 'function'
     ? actionCreator
     : identity;
 
+  const finalMetaCreator = typeof metaCreator === 'function'
+    ? metaCreator
+    : identity;
+
   return (...args) => ({
     type,
-    payload: finalActionCreator(...args)
+    payload: finalActionCreator(...args),
+    meta: finalMetaCreator(...args)
   });
 }

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -7,13 +7,14 @@ export default function createAction(type, actionCreator, metaCreator) {
     ? actionCreator
     : identity;
 
-  const finalMetaCreator = typeof metaCreator === 'function'
-    ? metaCreator
-    : identity;
+  return (...args) => {
+    const action = {
+      type,
+      payload: finalActionCreator(...args)
+    };
 
-  return (...args) => ({
-    type,
-    payload: finalActionCreator(...args),
-    meta: finalMetaCreator(...args)
-  });
+    if (typeof metaCreator === 'function') action.meta = metaCreator(...args);
+
+    return action;
+  };
 }


### PR DESCRIPTION
This addresses #3 and will be useful together with #2.

@acdlite Does it seem logical for you to just use `identity` if no meta creator has been passed? Seems better to me than omitting `meta` in that case.