### PR TITLE
implement FSA errors by setting error to true if payload is an Error obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ expect(increment(42)).to.deep.equal({
 });
 ```
 
+If the payload is an instance of an [Error
+object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error),
+redux-actions will automatically set ```action.error``` to true.
+
+Example:
+
+```js
+increment = createAction('INCREMENT');
+
+var error = new TypeError('not a number');
+expect(increment(error)).to.deep.equal({
+  type: 'INCREMENT',
+  payload: error,
+  error: true
+});
+```
+
 **NOTE:** The more correct name for this function is probably `createActionCreator()`, but that seems a bit redundant.
 
 Use the identity form to create one-off actions:

--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -51,5 +51,24 @@ describe('createAction()', () => {
         }
       });
     });
+
+    it('sets error to true if payload is an Error object', () => {
+      const actionCreator = createAction(type);
+      const errObj = new TypeError('this is an error');
+
+      const errAction = actionCreator(errObj);
+      expect(errAction).to.deep.equal({
+        type,
+        payload: errObj,
+        error: true
+      });
+
+      const foobar = { foo: 'bar', cid: 5 };
+      const noErrAction = actionCreator(foobar);
+      expect(noErrAction).to.deep.equal({
+        type,
+        payload: foobar
+      });
+    });
   });
 });

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -13,7 +13,14 @@ export default function createAction(type, actionCreator, metaCreator) {
       payload: finalActionCreator(...args)
     };
 
-    if (typeof metaCreator === 'function') action.meta = metaCreator(...args);
+    if (args.length === 1 && args[0] instanceof Error) {
+      // Handle FSA errors where the payload is an Error object. Set error.
+      action.error = true;
+    }
+
+    if (typeof metaCreator === 'function') {
+      action.meta = metaCreator(...args);
+    }
 
     return action;
   };


### PR DESCRIPTION
Noticed this spec of FSA wasn't yet implemented, and there's an issue for it.

This sets action.```error``` to true if the payload is a direct instance of ```Error```. This is the *faintest* touch of magic, but if it's documented, it makes sense.

Also fixes a possible error where we're trying to set action.meta even though action is a ```const```.

r? @acdlite 