### PR TITLE
Refactored default parameters of createAction function to avoid …

### DIFF
--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -25,7 +25,8 @@ describe('createAction()', () => {
       const action = actionCreator(foobar);
       expect(action).to.deep.equal({
         type,
-        payload: foobar
+        payload: foobar,
+        meta: {}
       });
     });
 
@@ -35,12 +36,13 @@ describe('createAction()', () => {
       const action = actionCreator(foobar);
       expect(action).to.deep.equal({
         type,
-        payload: foobar
+        payload: foobar,
+        meta: {}
       });
     });
 
     it('accepts a second parameter for adding meta to object', () => {
-      const actionCreator = createAction(type, null, ({ cid }) => ({ cid }));
+      const actionCreator = createAction(type, undefined, ({ cid }) => ({ cid }));
       const foobar = { foo: 'bar', cid: 5 };
       const action = actionCreator(foobar);
       expect(action).to.deep.equal({

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -2,18 +2,13 @@ function identity(t) {
   return t;
 }
 
-export default function createAction(type, actionCreator, metaCreator) {
-  const finalActionCreator = typeof actionCreator === 'function'
-    ? actionCreator
-    : identity;
-
+export default function createAction(type, actionCreator = identity, metaCreator = () => ({}) ) {
   return (...args) => {
     const action = {
       type,
-      payload: finalActionCreator(...args)
+      payload: actionCreator(...args),
+      meta: metaCreator(...args)
     };
-
-    if (typeof metaCreator === 'function') action.meta = metaCreator(...args);
 
     return action;
   };


### PR DESCRIPTION
…typechecks and potential undefined behavior when passing arbitrary objects instead of functions.

Hi acdlite, thanks for the nice project redux-actions. We'd like to propose a change of default parameter handling of the factory function createAction. This avoids undefined behavior of createAction when passing non function parameters as metaCreator or actionCreator.

Furthermore it ensures, that the meta field of the resulting action object is always defined (unless of course the metaCreator explicitly returns undefined ;-)