### PR TITLE
Sequence - use naming closer to the observable spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Wraps a reducer so that only handles Flux Standard Actions of a certain type.
 
 If a single reducer is passed, it is used to handle both normal actions and failed actions. (A failed action is analogous to a rejected promise.) You can use this form if you know a certain type of action will never fail, like the increment example above.
 
-Otherwise, you can specify separate reducers for `next()` and `throw()`. This API is inspired by the ES6 generator interface.
+Otherwise, you can specify separate reducers for `next()` and `error()`. This API is inspired by the ES6 generator interface.
 
 ```js
 handleAction('FETCH_DATA', {
-  next(state, action) {...}
-  throw(state, action) {...}
+  next(state, action) {...},
+  error(state, action) {...}
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "eslint": "^0.24.0",
     "eslint-config-airbnb": "0.0.6",
     "lodash.isplainobject": "^3.2.0",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "sinon": "^1.16.1"
   },
   "dependencies": {
     "flux-standard-action": "^0.6.0",

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -79,9 +79,9 @@ describe('handleAction()', () => {
           });
       });
 
-      it('uses `throw()` if action represents an error', () => {
+      it('uses `error()` if action represents an error', () => {
         const reducer = handleAction(type, {
-          throw: (state, action) => ({
+          error: (state, action) => ({
             ...state,
             counter: state.counter + action.payload
           })

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -32,14 +32,6 @@ describe('handleAction()', () => {
 
         expect(reducerSpy.calledWith(prevState, action, 'foo', 'bar')).to.be.ok;
       });
-
-      it('throws when reducer is called with invalid number of arguments', () => {
-        const reducer = handleAction(type, () => ({}));
-
-        expect(() => {
-          reducer();
-        }).to.throw(/must be called with/);
-      });
     });
   });
 

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -1,4 +1,5 @@
 import { handleAction } from '../';
+import { spy } from 'sinon';
 
 describe('handleAction()', () => {
   const type = 'TYPE';
@@ -20,6 +21,24 @@ describe('handleAction()', () => {
           .to.eql({
             counter: 10
           });
+      });
+
+      it('passes extract arguments to handler', () => {
+        const reducerSpy = spy();
+        const reducer = handleAction(type, reducerSpy);
+        const action = { type, payload: 7 };
+
+        reducer(prevState, action, 'foo', 'bar');
+
+        expect(reducerSpy.calledWith(prevState, action, 'foo', 'bar')).to.be.ok;
+      });
+
+      it('throws when reducer is called with invalid number of arguments', () => {
+        const reducer = handleAction(type, () => ({}));
+
+        expect(() => {
+          reducer();
+        }).to.throw(/must be called with/);
       });
     });
   });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -73,15 +73,15 @@ describe('handleAction()', () => {
           });
       });
 
-      it('uses `return()` if action signals end of action sequence', () => {
+      it('uses `complete()` if action signals end of action sequence', () => {
         const reducer = handleAction(type, {
-          return: (state, action) => ({
+          complete: (state, action) => ({
             ...state,
             pending: state.pending.filter(id => id !== action.sequence.id)
           })
         });
         const initialState = { counter: 3, pending: [123, 456, 789] };
-        const action = { type, sequence: { type: 'return', id: 123 } };
+        const action = { type, sequence: { type: 'complete', id: 123 } };
         expect(reducer(initialState, action))
           .to.eql({
             counter: 3,

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -23,7 +23,7 @@ describe('handleAction()', () => {
           });
       });
 
-      it('passes extract arguments to handler', () => {
+      it('passes extra arguments to handler', () => {
         const reducerSpy = spy();
         const reducer = handleAction(type, reducerSpy);
         const action = { type, payload: 7 };

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -9,7 +9,7 @@ function inArray(array, val) {
 }
 
 function getHandlerKey(action) {
-  if (isError(action)) return 'throw';
+  if (isError(action)) return 'error';
 
   if (action.sequence && inArray(['start', 'complete'], action.sequence.type)) {
     return action.sequence.type;

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -19,7 +19,16 @@ function getHandlerKey(action) {
 }
 
 export default function handleAction(type, reducers) {
-  return (state, action) => {
+  return (...args) => {
+    if (args.length < 2) {
+      throw new Error(`reducer for ${type} must be called with (state, action, ...extraArgs)`);
+    }
+
+    // Fetch variables manually, destructuring causes unnecessary
+    // loop + extra allocations - https://gist.github.com/tappleby/f1933823c52224870014
+    const state = args[0];
+    const action = args[1];
+
     // If action type does not match, return previous state
     if (action.type !== type) return state;
 
@@ -34,7 +43,7 @@ export default function handleAction(type, reducers) {
     const reducer = reducersMap[handlerKey];
 
     return isFunction(reducer)
-      ? reducer(state, action)
+      ? reducer(...args)
       : state;
   };
 }

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -20,10 +20,6 @@ function getHandlerKey(action) {
 
 export default function handleAction(type, reducers) {
   return (...args) => {
-    if (args.length < 2) {
-      throw new Error(`reducer for ${type} must be called with (state, action, ...extraArgs)`);
-    }
-
     // Fetch variables manually, destructuring causes unnecessary
     // loop + extra allocations - https://gist.github.com/tappleby/f1933823c52224870014
     const state = args[0];

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -11,7 +11,7 @@ function inArray(array, val) {
 function getHandlerKey(action) {
   if (isError(action)) return 'throw';
 
-  if (action.sequence && inArray(['start', 'return'], action.sequence.type)) {
+  if (action.sequence && inArray(['start', 'complete'], action.sequence.type)) {
     return action.sequence.type;
   }
 


### PR DESCRIPTION
This PR is not necessarily intended to be merged but brings the sequence naming closer to the observable spec + the preferred naming discussed in acdlite/flux-standard-action#7.

Ive also tweaked the reducer to pass any extra arguments to the handler, this allows for cases when you need to pass dependant state into the handlers.

This version is published as a scoped package if you want to try it out: [@tappleby/redux-actions](https://www.npmjs.com/package/@tappleby/redux-actions)