### PR TITLE
let `handleAction` accept `defaultState` and small optimization of `handleActions`

### DIFF
--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -20,6 +20,13 @@ describe('handleAction()', () => {
             counter: 10
           });
       });
+
+      context('when given `defaultState` and called with `undefined`', () => {
+        it('returns a default state', () => {
+          const reducer = handleAction(type, state => state, 'default');
+          expect( reducer(undefined, {}) ).to.equal( 'default' );
+        });
+      });
     });
   });
 
@@ -59,6 +66,13 @@ describe('handleAction()', () => {
         expect(reducer(prevState, { type, payload: 123 })).to.equal(prevState);
         expect(reducer(prevState, { type, payload: 123, error: true }))
           .to.equal(prevState);
+      });
+    });
+
+    context('when given `defaultState` and called with `undefined`', () => {
+      it('returns a default state', () => {
+        const reducer = handleAction(type, { next: (state ) => state }, 'default');
+        expect( reducer(undefined, {}) ).to.equal( 'default' );
       });
     });
   });

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -4,8 +4,8 @@ function isFunction(val) {
   return typeof val === 'function';
 }
 
-export default function handleAction(type, reducers) {
-  return (state, action) => {
+export default function handleAction(type, reducers, defaultState) {
+  return (state = defaultState, action) => {
     // If action type does not match, return previous state
     if (action.type !== type) return state;
 

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -3,11 +3,11 @@ import ownKeys from './ownKeys';
 import reduceReducers from 'reduce-reducers';
 
 export default function handleActions(handlers, defaultState) {
-  const reducers = ownKeys(handlers).map(type => {
-    return handleAction(type, handlers[type]);
-  });
+  const reducers = ownKeys(handlers).map(type =>
+    handleAction(type, handlers[type])
+  );
 
-  return typeof defaultState !== 'undefined'
-    ? (state = defaultState, action) => reduceReducers(...reducers)(state, action)
-    : reduceReducers(...reducers);
+  const reduction = reduceReducers(...reducers);
+
+  return (state = defaultState, action) => reduction(state, action);
 }


### PR DESCRIPTION
There are two commits:

1. Allow `handleAction` to accept an optional default state.  This is critical for developers who do not pass in a default state when they construct their Redux store.

2. Reduce reducers in `handleActions` only once whether or not `defaultState` given.  Previously, if `defaultState` was given, `reduceReducers(...reducers)` was computed every time the store called the new reducer.  This commit removes the redundant calculations.  This commit also slightly simplifies some of the body of `handleActions`.

Thanks for the awesome work!  It's been very useful in my own work.