### PR TITLE
Add support for action creators used as object keys

### DIFF
--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -70,5 +70,16 @@ describe('createAction()', () => {
         payload: foobar
       });
     });
+
+    it('can be used as object key', () => {
+      const actionCreator1 = createAction('TYPE1');
+      const actionCreator2 = createAction('TYPE2');
+      const handlers = {
+        [actionCreator1]: () => {},
+        [actionCreator2]: () => {}
+      };
+      expect(Object.keys(handlers)).to.have.length(2);
+    });
+
   });
 });

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -2,15 +2,15 @@ function identity(t) {
   return t;
 }
 
-export default function createAction(type, actionCreator, metaCreator) {
-  const finalActionCreator = typeof actionCreator === 'function'
-    ? actionCreator
+export default function createAction(type, payloadCreator, metaCreator) {
+  const finalPayloadCreator = typeof payloadCreator === 'function'
+    ? payloadCreator
     : identity;
 
-  return (...args) => {
+  function actionCreator(...args) {
     const action = {
       type,
-      payload: finalActionCreator(...args)
+      payload: finalPayloadCreator(...args)
     };
 
     if (args.length === 1 && args[0] instanceof Error) {
@@ -23,5 +23,9 @@ export default function createAction(type, actionCreator, metaCreator) {
     }
 
     return action;
-  };
+  }
+
+  actionCreator.toString = () => type;
+
+  return actionCreator;
 }


### PR DESCRIPTION
```javascript
    it('can be used as object key', () => {
      const actionCreator1 = createAction('TYPE1');
      const actionCreator2 = createAction('TYPE2');
      const handlers = {
        [actionCreator1]: () => {},
        [actionCreator2]: () => {}
      };
      expect(Object.keys(handlers)).to.have.length(2);
    });
```