### PR TITLE
Ensure that the global Reflect object also has an ownKeys function

### DIFF
--- a/src/ownKeys.js
+++ b/src/ownKeys.js
@@ -1,5 +1,5 @@
 export default function ownKeys(object) {
-  if (typeof Reflect !== 'undefined') {
+  if (typeof Reflect !== 'undefined' && typeof Reflect.ownKeys === 'function') {
     return Reflect.ownKeys(object);
   }
 


### PR DESCRIPTION
We are using traceur and it generates a Reflect global without `ownKeys`. This commit further tests the Reflect global to ensure it has the needed function.