### PR TITLE
Keep flowtypes during compliation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,6 @@
 {
-  "stage": 0,
-  "loose": "all"
+  "blacklist": ["flow"],
+  "loose": "all",
+  "plugins": ["flow-comments"],
+  "stage": 0
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel": "^5.6.14",
     "babel-core": "^5.6.15",
     "babel-eslint": "^4.1.3",
+    "babel-plugin-flow-comments": "^1.0.9",
     "chai": "^3.0.0",
     "eslint": "^1.5.1",
     "eslint-config-airbnb": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-core": "^5.6.15",
-    "babel-eslint": "^3.1.20",
+    "babel-eslint": "^4.1.3",
     "chai": "^3.0.0",
-    "eslint": "^0.24.0",
-    "eslint-config-airbnb": "0.0.6",
+    "eslint": "^1.5.1",
+    "eslint-config-airbnb": "^0.1.0",
+    "eslint-plugin-react": "^3.5.1",
     "lodash.isplainobject": "^3.2.0",
     "mocha": "^2.2.5"
   },

--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -1,4 +1,5 @@
 import { createAction } from '../';
+import identity from '../identity';
 import isPlainObject from 'lodash.isplainobject';
 
 describe('createAction()', () => {
@@ -6,26 +7,26 @@ describe('createAction()', () => {
     const type = 'TYPE';
 
     it('returns plain object', () => {
-      const actionCreator = createAction(type, b => b);
+      const actionCreator = createAction(type, identity);
       const foobar = { foo: 'bar' };
       const action = actionCreator(foobar);
       expect(isPlainObject(action)).to.be.true;
     });
 
     it('uses return value as payload', () => {
-      const actionCreator = createAction(type, b => b);
+      const actionCreator = createAction(type, identity);
       const foobar = { foo: 'bar' };
       const action = actionCreator(foobar);
       expect(action.payload).to.equal(foobar);
     });
 
     it('has no extraneous keys', () => {
-      const actionCreator = createAction(type, b => b);
+      const actionCreator = createAction(type, identity);
       const foobar = { foo: 'bar' };
       const action = actionCreator(foobar);
       expect(action).to.deep.equal({
         type,
-        payload: foobar
+        payload: foobar,
       });
     });
 
@@ -35,7 +36,7 @@ describe('createAction()', () => {
       const action = actionCreator(foobar);
       expect(action).to.deep.equal({
         type,
-        payload: foobar
+        payload: foobar,
       });
     });
 
@@ -47,8 +48,8 @@ describe('createAction()', () => {
         type,
         payload: foobar,
         meta: {
-          cid: 5
-        }
+          cid: 5,
+        },
       });
     });
   });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -13,11 +13,11 @@ describe('handleAction()', () => {
 
       it('accepts single function as handler', () => {
         const reducer = handleAction(type, (state, action) => ({
-          counter: state.counter + action.payload
+          counter: state.counter + action.payload,
         }));
         expect(reducer(prevState, { type, payload: 7 }))
           .to.deep.equal({
-            counter: 10
+            counter: 10,
           });
       });
     });
@@ -33,24 +33,24 @@ describe('handleAction()', () => {
       it('uses `next()` if action does not represent an error', () => {
         const reducer = handleAction(type, {
           next: (state, action) => ({
-            counter: state.counter + action.payload
-          })
+            counter: state.counter + action.payload,
+          }),
         });
         expect(reducer(prevState, { type, payload: 7 }))
           .to.deep.equal({
-            counter: 10
+            counter: 10,
           });
       });
 
       it('uses `throw()` if action represents an error', () => {
         const reducer = handleAction(type, {
           throw: (state, action) => ({
-            counter: state.counter + action.payload
-          })
+            counter: state.counter + action.payload,
+          }),
         });
         expect(reducer(prevState, { type, payload: 7, error: true }))
           .to.deep.equal({
-            counter: 10
+            counter: 10,
           });
       });
 

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -4,21 +4,21 @@ describe('handleActions', () => {
   it('create a single handler from a map of multiple action handlers', () => {
     const reducer = handleActions({
       INCREMENT: ({ counter }, { payload: amount }) => ({
-        counter: counter + amount
+        counter: counter + amount,
       }),
 
       DECREMENT: ({ counter }, { payload: amount }) => ({
-        counter: counter - amount
-      })
+        counter: counter - amount,
+      }),
     });
 
     expect(reducer({ counter: 3 }, { type: 'INCREMENT', payload: 7 }))
       .to.deep.equal({
-        counter: 10
+        counter: 10,
       });
     expect(reducer({ counter: 10 }, { type: 'DECREMENT', payload: 7 }))
       .to.deep.equal({
-        counter: 3
+        counter: 3,
       });
   });
 
@@ -27,30 +27,30 @@ describe('handleActions', () => {
 
     const reducer = handleActions({
       [INCREMENT]: ({ counter }, { payload: amount }) => ({
-        counter: counter + amount
-      })
+        counter: counter + amount,
+      }),
     });
 
     expect(reducer({ counter: 3 }, { type: INCREMENT, payload: 7 }))
       .to.deep.equal({
-        counter: 10
+        counter: 10,
       });
   });
 
   it('accepts a default state as the second parameter', () => {
     const reducer = handleActions({
       INCREMENT: ({ counter }, { payload: amount }) => ({
-        counter: counter + amount
+        counter: counter + amount,
       }),
 
       DECREMENT: ({ counter }, { payload: amount }) => ({
-        counter: counter - amount
-      })
+        counter: counter - amount,
+      }),
     }, { counter: 3 });
 
     expect(reducer(undefined, { type: 'INCREMENT', payload: 7 }))
       .to.deep.equal({
-        counter: 10
+        counter: 10,
       });
   });
 });

--- a/src/__tests__/identity-test.js
+++ b/src/__tests__/identity-test.js
@@ -1,0 +1,8 @@
+import identity from '../identity';
+
+describe('identity()', () => {
+  it('returns the input', () => {
+    const input = {};
+    expect(identity(input)).to.equal(input);
+  });
+});

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -1,19 +1,33 @@
-function identity(t) {
-  return t;
-}
+/* @flow */
+import identity from './identity';
 
-export default function createAction(type, actionCreator, metaCreator) {
+export type ActionType = string;
+export type Action = {
+  type: ActionType;
+  payload: any;
+  error?: bool;
+  meta?: any;
+};
+type ActionCreator = (...args: any) => Action;
+
+export default function createAction(
+  type: ActionType,
+  actionCreator: Function,
+  metaCreator?: Function
+): ActionCreator {
   const finalActionCreator = typeof actionCreator === 'function'
     ? actionCreator
     : identity;
 
   return (...args) => {
-    const action = {
+    const action: Action = {
       type,
-      payload: finalActionCreator(...args)
+      payload: finalActionCreator(...args),
     };
 
-    if (typeof metaCreator === 'function') action.meta = metaCreator(...args);
+    if (typeof metaCreator === 'function') {
+      action.meta = metaCreator(...args);
+    }
 
     return action;
   };

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,26 +1,44 @@
+/* @flow */
+
 import { isError } from 'flux-standard-action';
 
-function isFunction(val) {
-  return typeof val === 'function';
-}
+import type {Action} from './createAction';
+import identity from './identity';
 
-export default function handleAction(type, reducers) {
+export type State = Object;
+export type Reducer = (state: State, action: Action) => State;
+export type ReducerMap = {
+  next?: Reducer;
+  throw?: Reducer;
+};
+
+export default function handleAction(
+  type: string,
+  reducers: Reducer | ReducerMap
+): Reducer {
   return (state, action) => {
     // If action type does not match, return previous state
-    if (action.type !== type) return state;
-
-    const handlerKey = isError(action) ? 'throw' : 'next';
-
-    // If function is passed instead of map, use as reducer
-    if (isFunction(reducers)) {
-      reducers.next = reducers;
+    if (action.type !== type) {
+      return state;
     }
 
-    // Otherwise, assume an action map was passed
-    const reducer = reducers[handlerKey];
+    let next;
+    let error;
 
-    return isFunction(reducer)
-      ? reducer(state, action)
-      : state;
+    // If function is passed instead of map, use as reducer
+    if (typeof reducers === 'function') {
+      next = reducers;
+      error = identity;
+    } else {
+      next = reducers.next || identity;
+      error = reducers.throw || identity;
+    }
+
+    const finalReducer = isError(action) ? error : next;
+    if (typeof finalReducer === 'function') {
+      return finalReducer(state, action);
+    }
+
+    return identity(state);
   };
 }

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -1,13 +1,25 @@
+/* @flow */
+
 import handleAction from './handleAction';
 import ownKeys from './ownKeys';
 import reduceReducers from 'reduce-reducers';
 
-export default function handleActions(handlers, defaultState) {
+import {ActionType} from './createAction';
+import {State, Reducer, ReducerMap} from './handleAction';
+
+type Handlers = {
+  [type: ActionType]: Reducer | ReducerMap;
+};
+
+export default function handleActions(
+  handlers: Handlers,
+  defaultState: ?State
+): State {
   const reducers = ownKeys(handlers).map(type => {
     return handleAction(type, handlers[type]);
   });
 
-  return typeof defaultState !== 'undefined'
+  return defaultState !== undefined
     ? (state = defaultState, action) => reduceReducers(...reducers)(state, action)
     : reduceReducers(...reducers);
 }

--- a/src/identity.js
+++ b/src/identity.js
@@ -1,0 +1,6 @@
+/* @flow */
+
+export default function identity<T>(id: T): T {
+  return id;
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+/* @flow */
 import createAction from './createAction';
 import handleAction from './handleAction';
 import handleActions from './handleActions';
@@ -5,5 +6,5 @@ import handleActions from './handleActions';
 export {
   createAction,
   handleAction,
-  handleActions
+  handleActions,
 };


### PR DESCRIPTION
Keep the flowtypes introduced in #36 during the compilation, making them available to consumers of redux-actions.