### PR TITLE
Fix issue when rejecting a promise for a single reducer

### DIFF
--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -13,7 +13,7 @@ export default function handleAction(type, reducers) {
 
     // If function is passed instead of map, use as reducer
     if (isFunction(reducers)) {
-      reducers.next = reducers;
+      reducers.next = reducers.throw = reducers;
     }
 
     // Otherwise, assume an action map was passed


### PR DESCRIPTION
Fix for the following issue:

If I'm using handleAction with a single reducer rather than a reducerMap, then rejecting a promise will not make it to the reducer.