### PR TITLE
fix: remove unnecessary files from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "test": "make test",
     "prepublish": "make clean build"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "keywords": [
     "flux",
     "redux",


### PR DESCRIPTION
Same reason as [react-redux@4.0.1](https://github.com/rackt/react-redux/releases/tag/v4.0.1). `.babelrc` with `stage` option fails build @ react-native@0.16.