### PR TITLE
Remove .babelrc from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src
+.babelrc


### PR DESCRIPTION
Fixes issues with redux-actions in react-native. See [here](https://github.com/facebook/react-native/issues/4674) for more.