### PR TITLE
Remove .npmignore and just publish lib files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-.babelrc
-src

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "prepublish": "make clean build"
   },
   "files": [
-    "src",
-    "lib"
+    "lib/*.js"
   ],
   "keywords": [
     "flux",


### PR DESCRIPTION
```bash
$ pkgfiles

PATH                                 SIZE      %
lib/__tests__/init.js                230 B     1%
lib/ownKeys.js                       453 B     3%
lib/index.js                         624 B     4%
lib/handleAction.js                  814 B     5%
lib/createAction.js                  862 B     5%
package.json                         972 B     6%
lib/handleActions.js                 986 B     6%
lib/__tests__/handleActions-test.js  1.97 kB   12%
lib/__tests__/handleAction-test.js   2.41 kB   15%
lib/__tests__/createAction-test.js   2.56 kB   16%
README.md                            4.5 kB    27%
```