### PR TITLE
Support error functionality in all payload creators

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-core": "^5.6.15",
-    "babel-eslint": "^3.1.20",
+    "babel-eslint": "^5.0.0",
     "chai": "^3.0.0",
     "eslint": "^0.24.0",
     "eslint-config-airbnb": "0.0.6",

--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -55,13 +55,18 @@ describe('createAction()', () => {
     it('sets error to true if payload is an Error object', () => {
       const actionCreator = createAction(type);
       const errObj = new TypeError('this is an error');
-
-      const errAction = actionCreator(errObj);
-      expect(errAction).to.deep.equal({
+      const expectedErrorAction = {
         type,
         payload: errObj,
         error: true
-      });
+      };
+
+      const errAction = actionCreator(errObj);
+      expect(errAction).to.deep.equal(expectedErrorAction);
+
+      const originalActionContext = { query: { offset: 10, count: 5 } };
+      const otherErrAction = actionCreator(errObj, originalActionContext);
+      expect(otherErrAction).to.deep.equal(expectedErrorAction);
 
       const foobar = { foo: 'bar', cid: 5 };
       const noErrAction = actionCreator(foobar);

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -13,7 +13,7 @@ export default function createAction(type, actionCreator, metaCreator) {
       payload: finalActionCreator(...args)
     };
 
-    if (args.length === 1 && args[0] instanceof Error) {
+    if (args[0] instanceof Error) {
       // Handle FSA errors where the payload is an Error object. Set error.
       action.error = true;
     }

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -6,7 +6,7 @@ export default function handleActions(handlers, defaultState) {
   const reducers = ownKeys(handlers).map(type => {
     return handleAction(type, handlers[type]);
   });
-  const reducer = reduceReducers(...reducers)
+  const reducer = reduceReducers(...reducers);
 
   return typeof defaultState !== 'undefined'
     ? (state = defaultState, action) => reducer(state, action)


### PR DESCRIPTION
The expected functionality of `createAction` is that it will create an action with `error: true` if the payload is an instance of `Error`. Currently, we don't get this functionality if the payload creator has an arity greater than 1. I'm not completely convinced that this is reasonable. 

Consider a scenario where an initial "optimistic" action sets some transient state in store where that state is keyed by some data in the action. For example,

```javascript
{
  type: UPDATE_FILTERS,
  payload: {
    filters: { /* ... */ }  // `filters` value becomes the key in a Map within the store
  }
}
```

If the subsequent side effect fails then `payload` is occupied with an `Error` instance:

```javascript
{
  type: UPDATE_FILTERS,
  payload: new Error("Some message from the API"),
  error: true
}
```

With the action above, I've lost the ability to associate the failure to the original action, more specifically the `filters` value in the initial action's payload. Therefore, I cannot update the transient state that I set. Ideally, I would do something like this:

```javascript
{
  type: UPDATE_FILTERS,
  payload: new Error("Some message from the API"),
  error: true,
  meta: {
    filters: { /* ... */ }
  }
}
```

But in order to achieve that, I need to pass more than one argument to the action creator, i.e.,

```javascript
myActionCreator(
  new Error(response.message),
  moreContext
)
```

I don't think it's reasonable to have to serialize that extra context within the `Error` message just to deserialize it again almost immediately after. I suppose I can attach the extra context directly onto the `Error` object but before I consider that I'm curious as to why there is an explicit constraint on payload creator arity to begin with.

I'm also open to any other suggestions.