### PR TITLE
createAction should adhere to doc contract regarding errors

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -13,7 +13,7 @@ export default function createAction(type, actionCreator, metaCreator) {
       payload: finalActionCreator(...args)
     };
 
-    if (args.length === 1 && args[0] instanceof Error) {
+    if (action.payload instanceof Error) {
       // Handle FSA errors where the payload is an Error object. Set error.
       action.error = true;
     }


### PR DESCRIPTION
Specifically, the documentation states the following:

> If the payload is an instance of an Error object, redux-actions will automatically set action.error to true.

This implies that, irrespective of the arguments provided to `createAction`, if the resulting `payload` is an Error object then the `action.error` property should be set to true.

This just changes that check to ensure it is performed as stated in the docs.