### PR TITLE
Use flux-standard-action dependency for test only

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "eslint-config-airbnb-base": "^1.0.3",
     "eslint-plugin-import": "^1.5.0",
     "lodash.isplainobject": "^3.2.0",
+    "flux-standard-action": "^0.6.0",
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "flux-standard-action": "^0.6.0",
     "reduce-reducers": "^0.1.0"
   }
 }

--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -1,25 +1,18 @@
 import { createAction } from '../';
-import isPlainObject from 'lodash.isplainobject';
+import { isFSA } from 'flux-standard-action';
 
 describe('createAction()', () => {
   describe('resulting action creator', () => {
     const type = 'TYPE';
 
-    it('returns plain object', () => {
+    it('returns a valid FSA', () => {
       const actionCreator = createAction(type, b => b);
       const foobar = { foo: 'bar' };
       const action = actionCreator(foobar);
-      expect(isPlainObject(action)).to.be.true;
+      expect(isFSA(action)).to.be.true;
     });
 
     it('uses return value as payload', () => {
-      const actionCreator = createAction(type, b => b);
-      const foobar = { foo: 'bar' };
-      const action = actionCreator(foobar);
-      expect(action.payload).to.equal(foobar);
-    });
-
-    it('has no extraneous keys', () => {
       const actionCreator = createAction(type, b => b);
       const foobar = { foo: 'bar' };
       const action = actionCreator(foobar);
@@ -37,6 +30,7 @@ describe('createAction()', () => {
         type,
         payload: foobar
       });
+      expect(isFSA(action)).to.be.true;
     });
 
     it('accepts a second parameter for adding meta to object', () => {
@@ -50,6 +44,7 @@ describe('createAction()', () => {
           cid: 5
         }
       });
+      expect(isFSA(action)).to.be.true;
     });
 
     it('sets error to true if payload is an Error object', () => {
@@ -62,6 +57,7 @@ describe('createAction()', () => {
         payload: errObj,
         error: true
       });
+      expect(isFSA(errAction)).to.be.true;
 
       const foobar = { foo: 'bar', cid: 5 };
       const noErrAction = actionCreator(foobar);
@@ -69,6 +65,7 @@ describe('createAction()', () => {
         type,
         payload: foobar
       });
+      expect(isFSA(noErrAction)).to.be.true;
     });
   });
 });

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,5 +1,3 @@
-import { isError } from 'flux-standard-action';
-
 function isFunction(val) {
   return typeof val === 'function';
 }
@@ -9,7 +7,7 @@ export default function handleAction(type, reducers) {
     // If action type does not match, return previous state
     if (action.type !== type) return state;
 
-    const handlerKey = isError(action) ? 'throw' : 'next';
+    const handlerKey = action.error === true ? 'throw' : 'next';
 
     // If function is passed instead of map, use as reducer
     if (isFunction(reducers)) {


### PR DESCRIPTION
Including FSA means adding unneeded dependencies. We keep using it inside tests so we ensure consistency. Closes #60 
Note: I've removed "has no extraneous key" test because `isFSA()` already does that check.