### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-core": "^5.6.15",
-    "babel-eslint": "^3.1.20",
+    "babel-eslint": "^4.1.8",
     "chai": "^3.0.0",
     "eslint": "^0.24.0",
     "eslint-config-airbnb": "0.0.6",

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -6,7 +6,7 @@ export default function handleActions(handlers, defaultState) {
   const reducers = ownKeys(handlers).map(type => {
     return handleAction(type, handlers[type]);
   });
-  const reducer = reduceReducers(...reducers)
+  const reducer = reduceReducers(...reducers);
 
   return typeof defaultState !== 'undefined'
     ? (state = defaultState, action) => reducer(state, action)


### PR DESCRIPTION
Conservatively bump babel-eslint to fix upstream bug that was breaking this build, as well as fix a missing semi-colon eslint violation.