### PR TITLE
Add type property to generated action creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ let increment = createAction('INCREMENT', amount => amount);
 // same as
 increment = createAction('INCREMENT');
 
+expect(increment.type).to.equal('INCREMENT')
 expect(increment(42)).to.deep.equal({
   type: 'INCREMENT',
   payload: 42

--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -70,5 +70,10 @@ describe('createAction()', () => {
         payload: foobar
       });
     });
+
+    it('contains the type in the "type" property', () => {
+      const actionCreator = createAction(type, b => b);
+      expect(actionCreator.type).to.equal(type);
+    })
   });
 });

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -7,7 +7,7 @@ export default function createAction(type, actionCreator, metaCreator) {
     ? actionCreator
     : identity;
 
-  return (...args) => {
+  const generatedActionCreator = (...args) => {
     const action = {
       type,
       payload: finalActionCreator(...args)
@@ -24,4 +24,9 @@ export default function createAction(type, actionCreator, metaCreator) {
 
     return action;
   };
+  Object.defineProperty(generatedActionCreator, 'type', {
+    value: type,
+    writable: false
+  });
+  return generatedActionCreator;
 }


### PR DESCRIPTION
This comes in handy to have a singular representation of an action, whether using the function for dispatching or the type for reducers/sagas/etc.