### PR TITLE
Upgrade ESLint dependencies and fix tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "eslint-config-airbnb",
+  "extends": "airbnb-base",
   "env": {
     "mocha": true,
     "node": true
@@ -8,9 +8,11 @@
     "expect": true
   },
   "rules": {
+    "comma-dangle": [2, "never"],
     "padded-blocks": 0,
     "no-use-before-define": [2, "nofunc"],
     "no-unused-expressions": 0,
+    "no-param-reassign": 0,
     "no-reserved-keys": 0,
     "space-infix-ops": 0
   }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-core": "^5.6.15",
-    "babel-eslint": "^3.1.20",
     "chai": "^3.0.0",
-    "eslint": "^0.24.0",
-    "eslint-config-airbnb": "0.0.6",
+    "eslint": "^2.8.0",
+    "eslint-config-airbnb-base": "^1.0.3",
+    "eslint-plugin-import": "^1.5.0",
     "lodash.isplainobject": "^3.2.0",
     "mocha": "^2.2.5"
   },

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -3,10 +3,8 @@ import ownKeys from './ownKeys';
 import reduceReducers from 'reduce-reducers';
 
 export default function handleActions(handlers, defaultState) {
-  const reducers = ownKeys(handlers).map(type => {
-    return handleAction(type, handlers[type]);
-  });
-  const reducer = reduceReducers(...reducers)
+  const reducers = ownKeys(handlers).map(type => handleAction(type, handlers[type]));
+  const reducer = reduceReducers(...reducers);
 
   return typeof defaultState !== 'undefined'
     ? (state = defaultState, action) => reducer(state, action)


### PR DESCRIPTION
- Upgrade `eslint` to latest version
- Remove `babel-eslint`, because `eslint` has ES6 support
- Remove `eslint-config-airbnb`
- Add and use `eslint-config-airbnb-base`
- Add `eslint-plugin-import`
- Overwrite `eslint-config-airbnb-base` rules to match current style (except `arrow-body-style`)
- Fix missing `semicolon`

This would close #78 and #62.