### PR TITLE
Adds TypeScript typings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ clean:
 test: lint
 	NODE_ENV=test $(BIN)/mocha $(MOCHA_ARGS) $(MOCHA_TARGET)
 
+test-typings:
+	if [ ! -f $(BIN)/tsc ]; then npm install typescript; fi
+	$(BIN)/tsc --noEmit --noImplicitAny src/__tests__/typescript-typings-test.ts
+
 test-watch: lint
 	NODE_ENV=test $(BIN)/mocha $(MOCHA_ARGS) -w $(MOCHA_TARGET)
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "make test",
+    "test-typings": "make test-typings",
     "prepublish": "make clean build"
   },
   "files": [
     "src",
     "lib"
   ],
+  "typings": "./redux-actions.d.ts",
   "keywords": [
     "flux",
     "redux",

--- a/redux-actions.d.ts
+++ b/redux-actions.d.ts
@@ -1,0 +1,65 @@
+declare namespace ReduxActions {
+    interface BaseAction {
+        type: string
+    }
+
+    interface Action<Payload> extends BaseAction {
+        payload?: Payload
+        error?: boolean
+        meta?: any
+    }
+
+    interface ActionMeta<Payload, Meta> extends Action<Payload> {
+        meta: Meta
+    }
+
+    type PayloadCreator<Input, Payload> = (...args: Input[]) => Payload;
+
+    type MetaCreator<Input, Payload> = (...args: Input[]) => Payload;
+
+    type Reducer<Payload> = (state: Payload, action: Action<Payload>) => Payload;
+
+    type ReducerMeta<Payload, Meta> = (state: Payload, action: ActionMeta<Payload, Meta>) => Payload;
+
+    type ReducerMap<Payload> = {
+        [actionType: string]: Reducer<Payload>
+    };
+
+    export function createAction(
+        actionType: string,
+        payloadCreator?: PayloadCreator<any, any>,
+        metaCreator?: MetaCreator<any, any>
+    ): (...args: any[]) => Action<any>;
+
+    export function createAction<InputAndPayload>(
+        actionType: string,
+        payloadCreator?: PayloadCreator<InputAndPayload, InputAndPayload>
+    ): (...args: InputAndPayload[]) => Action<InputAndPayload>;
+
+    export function createAction<Input, Payload>(
+        actionType: string,
+        payloadCreator?: PayloadCreator<Input, Payload>
+    ): (...args: Input[]) => Action<Payload>;
+
+    export function createAction<Input, Payload, Meta>(
+        actionType: string,
+        payloadCreator: PayloadCreator<Input, Payload>,
+        metaCreator: MetaCreator<Input, Meta>
+    ): (...args: Input[]) => ActionMeta<Payload, Meta>;
+
+    export function handleAction<Payload>(
+        actionType: string,
+        reducer: Reducer<Payload> | ReducerMap<Payload>
+    ): Reducer<Payload>;
+
+    export function handleAction<Payload, Meta>(
+        actionType: string,
+        reducer: ReducerMeta<Payload, Meta> | ReducerMap<Payload>
+    ): Reducer<Payload>;
+
+    export function handleActions<Payload>(reducerMap: ReducerMap<Payload>, initialState?: Payload): Reducer<Payload>;
+}
+
+declare module 'redux-actions' {
+    export = ReduxActions;
+}

--- a/src/__tests__/typescript-typings-test.ts
+++ b/src/__tests__/typescript-typings-test.ts
@@ -1,0 +1,98 @@
+/// <reference path="../../redux-actions.d.ts" />
+
+let state: number;
+const minimalAction: ReduxActions.BaseAction = { type: 'INCREMENT' };
+
+const incrementAction: () => ReduxActions.Action<number> = ReduxActions.createAction<number>(
+    'INCREMENT', () => 1
+);
+
+const multiplyAction: (...args: number[]) => ReduxActions.Action<number> = ReduxActions.createAction<number>(
+    'MULTIPLY'
+);
+
+const action: ReduxActions.Action<number> = incrementAction();
+
+const actionHandler = ReduxActions.handleAction<number>(
+    'INCREMENT',
+    (state: number, action: ReduxActions.Action<number>) => state + action.payload
+);
+
+state = actionHandler(0, incrementAction());
+
+const actionHandlerWithReduceMap = ReduxActions.handleAction<number>(
+    'MULTIPLY', {
+        next(state: number, action: ReduxActions.Action<number>) {
+            return state * action.payload;
+        },
+        throw(state: number) { return state }
+    }
+);
+
+state = actionHandlerWithReduceMap(0, multiplyAction(10));
+
+const actionsHandler = ReduxActions.handleActions<number>({
+    'INCREMENT': (state: number, action: ReduxActions.Action<number>) => state + action.payload,
+    'MULTIPLY': (state: number, action: ReduxActions.Action<number>) => state * action.payload
+});
+
+state = actionsHandler(0, { type: 'INCREMENT' });
+
+const actionsHandlerWithInitialState = ReduxActions.handleActions<number>({
+    'INCREMENT': (state: number, action: ReduxActions.Action<number>) => state + action.payload,
+    'MULTIPLY': (state: number, action: ReduxActions.Action<number>) => state * action.payload
+}, 0);
+
+state = actionsHandlerWithInitialState(0, { type: 'INCREMENT' });
+
+// ----------------------------------------------------------------------------------------------------
+
+type TypedState = {
+    value: number;
+};
+
+type MetaType = {
+    remote: boolean
+};
+
+let typedState: TypedState;
+
+const richerAction: ReduxActions.ActionMeta<TypedState, MetaType> = {
+    type: 'INCREMENT',
+    error: false,
+    payload: {
+        value: 2
+    },
+    meta: {
+        remote: true
+    }
+};
+
+const typedIncrementAction: () => ReduxActions.Action<TypedState> = ReduxActions.createAction<TypedState>(
+    'INCREMENT',
+    () => ({ value: 1 })
+);
+
+const typedActionHandler = ReduxActions.handleAction<TypedState>(
+    'INCREMENT',
+    (state: TypedState, action: ReduxActions.Action<TypedState>) => ({ value: state.value + 1 })
+);
+
+typedState = typedActionHandler({ value: 0 }, typedIncrementAction());
+
+const typedIncrementByActionWithMeta: (value: number) => ReduxActions.ActionMeta<TypedState, MetaType> = ReduxActions.createAction<number, TypedState, MetaType>(
+    'INCREMENT_BY',
+    amount => ({ value: amount }),
+    amount => ({ remote: true })
+);
+
+const typedActionHandlerWithReduceMap = ReduxActions.handleAction<TypedState>(
+    'INCREMENT_BY', {
+        next(state: TypedState, action: ReduxActions.Action<TypedState>) {
+            return { value: state.value + action.payload.value };
+        },
+        throw(state: TypedState) { return state }
+    }
+);
+
+typedState = typedActionHandlerWithReduceMap({ value: 0 }, typedIncrementByActionWithMeta(10));


### PR DESCRIPTION
This PR adds TypeScript typings to the packages without changes to the source files (I'd also be open to make a PR to convert the code base to TypeScript).

There's now `make test-typings` or `npm run test-typings` that will install `npm install typescript` if it's not installed locally already and run a test. I decided not to make this a part of a regular test in order to avoid making TypeScript a package dependency, but I'm happy to update and make it run all together.

What do you think?