### PR TITLE
Simplified implementation of handleAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ handleAction('FETCH_DATA', {
 });
 ```
 
+If you leave either reducer unspecified, the wrapped reducer will treat that reducer as a no-op, returning the state unchanged.
+
+```js
+handleAction('FETCH_DATA', {
+  next(state, action) {...}
+  // State will be unchanged in the event of an error
+});
+```
+
 The optional third parameter specifies a default or initial state, which is used when `undefined` is passed to the reducer.
 
 ### `handleActions(reducerMap, ?defaultState)`

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -12,7 +12,9 @@ export default function handleAction(type, reducers, defaultState) {
     : [reducers.next, reducers.throw];
 
   if (nextReducer === undefined || throwReducer === undefined) {
-    throw TypeError("reducers argument must be either a function or an object of shape {next, throw}");
+    throw new TypeError(
+      'reducers argument must be either a function or an object of shape {next, throw}'
+    );
   }
 
   return (state = defaultState, action) => {

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -7,19 +7,14 @@ export default function handleAction(type, reducers, defaultState) {
     ? type.toString()
     : type;
 
+  const nextReducer = isFunction(reducers) ? reducers : reducers.next;
+  const throwReducer = isFunction(reducers) ? reducers : reducers.throw;
+
   return (state = defaultState, action) => {
     // If action type does not match, return previous state
     if (action.type !== typeValue) return state;
 
-    const handlerKey = action.error === true ? 'throw' : 'next';
-
-    // If function is passed instead of map, use as reducer
-    if (isFunction(reducers)) {
-      reducers.next = reducers.throw = reducers;
-    }
-
-    // Otherwise, assume an action map was passed
-    const reducer = reducers[handlerKey];
+    const reducer = action.error === true ? throwReducer : nextReducer;
 
     return isFunction(reducer)
       ? reducer(state, action)

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -7,8 +7,9 @@ export default function handleAction(type, reducers, defaultState) {
     ? type.toString()
     : type;
 
-  const nextReducer = isFunction(reducers) ? reducers : reducers.next;
-  const throwReducer = isFunction(reducers) ? reducers : reducers.throw;
+  const [nextReducer, throwReducer] = isFunction(reducers)
+    ? [reducers, reducers]
+    : [reducers.next, reducers.throw];
 
   return (state = defaultState, action) => {
     // If action type does not match, return previous state

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -3,7 +3,7 @@ function isFunction(val) {
 }
 
 function coerceReducer(reducer) {
-  return isFunction(reducer) ? reducer : (state, action) => state
+  return isFunction(reducer) ? reducer : state => state;
 }
 
 export default function handleAction(type, reducers, defaultState) {
@@ -22,6 +22,6 @@ export default function handleAction(type, reducers, defaultState) {
 
     const reducer = action.error === true ? throwReducer : nextReducer;
 
-    return reducer(state, action)
+    return reducer(state, action);
   };
 }

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -11,6 +11,10 @@ export default function handleAction(type, reducers, defaultState) {
     ? [reducers, reducers]
     : [reducers.next, reducers.throw];
 
+  if (nextReducer === undefined || throwReducer === undefined) {
+    throw TypeError("reducers argument must be either a function or an object of shape {next, throw}");
+  }
+
   return (state = defaultState, action) => {
     // If action type does not match, return previous state
     if (action.type !== typeValue) return state;

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -16,15 +16,15 @@ export default function handleAction(type, reducers, defaultState) {
     : [reducers.next, reducers.throw];
   // TODO: warn if both reducers are undefined or identity; that would make this a no-op reducer.
 
-  // TODO: relace this kludge with flow or some other proper type checker. 
+  // TODO: relace this kludge with flow or some other proper type checker.
   if (!isFunction(nextReducer)) {
     throw new TypeError(
-      "If given, reducers or reducers.next must be a function (got " + nextReducer + ")"
+      `If given, reducers or reducers.next must be a function (got ${nextReducer})`
     );
   }
   if (!isFunction(throwReducer)) {
     throw new TypeError(
-      "If given, reducers or reducers.throw must be a function (got " + throwReducer + ")"
+      `If given, reducers or reducers.throw must be a function (got ${throwReducer})`
     );
   }
 


### PR DESCRIPTION
- Moved the function-or-object check on the `reducers` parameter to outside the closure function
- Removed the use of magic strings
- Removed the mutation of the passed-in `reducers` argument