### PR TITLE
new feature createActions() - supports actionMap, defaultActions, and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,15 @@ createAction('ADD_TODO')('Use Redux');
 
 Create multiple actions and return an object mapping from the type to the actionCreator. This eliminates some of the repetitiveness when creating many actions.
 
-If actionMap is provided as first argument, an action will be created for each item in the map. The key will be used for the type. The value will be treated as follows:
+If `actionMap` is provided as first argument, an action will be created for each item in the map. The key will be used for the type. The value will be treated as follows:
 
  - if value is a function then it will be assumed to be the payloadCreator function
  - if value is an object then it will accept as its keys payload and meta, both of which are functions that will serve as they payloadCreator and/or metaCreator. If payloadCreator is missing the default payloadCreator is used. If metaCreator is missing then it will not use one.
  - otherwise create a default actionCreator for the key type
 
-If an array of string is provided as arrayDefTypes it will be used to create default actionCreators using the string for the action type.
+If an array of string is provided as `arrayDefTypes` it will be used to create default actionCreators using the string for the action type.
 
-If an optionMap object is supplied as last argument then it will adjust the options createActions uses in operation:
+If an `optionMap` object is supplied as last argument then it will adjust the options createActions uses in operation:
 
  - `prefix` - string, prefix all action types with this prefix, default ''
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Create multiple actions and return an object mapping from the type to the action
 If `actionMap` is provided as first argument, an action will be created for each item in the map. The key will be used for the type. The value will be treated as follows:
 
  - if value is a function then it will be assumed to be the payloadCreator function
- - if value is an object then it will accept as its keys payload and meta, both of which are functions that will serve as they payloadCreator and/or metaCreator. If payloadCreator is missing the default payloadCreator is used. If metaCreator is missing then it will not use one.
+ - if value is an object then it will accept as its keys, `payload` and `meta`, both of which are functions that will serve as the payloadCreator and/or metaCreator. If payloadCreator is missing the default payloadCreator is used. If metaCreator is missing then it will not use one.
  - otherwise create a default actionCreator for the key type
 
 If an array of string is provided as `arrayDefTypes` it will be used to create default actionCreators using the string for the action type.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ redux-actions
 npm install --save redux-actions
 ```
 ```js
-import { createAction, handleAction, handleActions } from 'redux-actions';
+import { createAction, createActions, handleAction, handleActions } from 'redux-actions';
 ```
 
 ### `createAction(type, payloadCreator = Identity, ?metaCreator)`
@@ -77,6 +77,117 @@ createAction('ADD_TODO')('Use Redux');
 ```
 
 `metaCreator` is an optional function that creates metadata for the payload. It receives the same arguments as the payload creator, but its result becomes the meta field of the resulting action. If `metaCreator` is undefined or not a function, the meta field is omitted.
+
+### `createActions(?actionMap, ?arrayDefTypes, ?optionMap)`
+
+Create multiple actions and return an object mapping from the type to the actionCreator. This eliminates some of the repetitiveness when creating many actions.
+
+If actionMap is provided as first argument, an action will be created for each item in the map. The key will be used for the type. The value will be treated as follows:
+
+ - if value is a function then it will be assumed to be the payloadCreator function
+ - if value is an object then it will accept as its keys payload and meta, both of which are functions that will serve as they payloadCreator and/or metaCreator. If payloadCreator is missing the default payloadCreator is used. If metaCreator is missing then it will not use one.
+ - otherwise create a default actionCreator for the key type
+
+If an array of string is provided as arrayDefTypes it will be used to create default actionCreators using the string for the action type.
+
+If an optionMap object is supplied as last argument then it will adjust the options createActions uses in operation:
+
+ - `prefix` - string, prefix all action types with this prefix, default ''
+
+#### Example: simple default actions
+
+```js
+import { createActions } from 'redux-actions';
+const a = createActions(['ONE', 'TWO', 'THREE']);
+
+// is equivalent to
+const a = {
+  ONE: createAction('ONE'),
+  TWO: createAction('TWO'),
+  THREE: createAction('THREE')
+;}
+```
+
+#### Example: simple default actions with prefix
+
+```js
+import { createActions } from 'redux-actions';
+const a = createActions(['ONE', 'TWO', 'THREE'], { prefix: 'ns/');
+
+// is equivalent to
+const a = {
+  ONE: createAction('ns/ONE'),
+  TWO: createAction('ns/TWO'),
+  THREE: createAction('ns/THREE')
+;}
+```
+
+#### Example: using actionMap
+
+```js
+import { createActions } from 'redux-actions';
+const a = createActions({
+  ONE: (b, c) => ({ bar: b, cat: c }),  // payload creator
+  TWO: {
+    payload: (d, e) => [d, e]            // payload creator
+    meta: (d, e) => ({ time: Date.now() }) // meta creator
+  },
+  THREE: {
+    meta: f => ({ id: shortid() })
+  }
+});
+
+
+// is equivalent to
+const a = {
+  ONE: createAction('ONE', (b, c) => ({ bar: b, cat: c })),
+  TWO: createAction('TWO',
+                    (d, e) => [d, e],
+                    (d, e) => ({ time: Date.now() })),
+  THREE: createAction('THREE',
+                      undefined,  // used default payload creator
+                      f => ({ id: shortid() }))
+});
+```
+
+#### Example full createActions functionality
+
+```js
+import { createActions } from 'redux-actions';
+const a = createActions(
+  {
+    ONE: (b, c) => ({ bar: b, cat: c }),  // payload creator
+    TWO: {
+      payload: (d, e) => [d, e]            // payload creator
+      meta: (d, e) => ({ time: Date.now() }) // meta creator
+    },
+    THREE: {
+      meta: f => ({ id: shortid() })
+    }
+  }, [ // arrayDefTypes creates defaultActions
+    'FOUR',
+    'FIVE',
+    'SIX'
+  ], {  // options
+    prefix: 'ns/'
+  }
+);
+
+// is equivalent to
+const a = {
+  ONE: createAction('ns/ONE', (b, c) => ({ bar: b, cat: c })),
+  TWO: createAction('ns/TWO',
+                    (d, e) => [d, e],
+                    (d, e) => ({ time: Date.now() })),
+  THREE: createAction('ns/THREE',
+                      undefined,  // used default payload creator
+                      f => ({ id: shortid() })),
+  FOUR: createAction('ns/FOUR'),
+  FIVE: createAction('ns/FIVE'),
+  SIX: createAction('ns/SIX')
+};
+```
+
 
 ### `handleAction(type, reducer | reducerMap, ?defaultState)`
 

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -1,0 +1,212 @@
+import { createActions } from '../';
+import { isFSA } from 'flux-standard-action';
+
+describe('createActions', () => {
+  describe('createActions(actionMap)', () => {
+    it('returns an object with actions for each key', () => {
+      const a = createActions({
+        one: (b, c) => ({ bat: b, cat: c }),
+        two: {
+          payload: (d, e) => ({ dog: d, egg: e }),
+          meta: (/* d, e */) => ({ zed: 1 })
+        },
+        three: {
+          meta: (/* f */) => ({ zed: 2 })
+        }
+      });
+      expect(a).to.be.instanceOf(Object);
+      const a1 = a.one(1, 2);
+      expect(a1).to.eql({ type: 'one', payload: { bat: 1, cat: 2 } });
+      expect(isFSA(a1)).to.be.true;
+      expect(a.one.toString()).to.equal('one');
+      const a2 = a.two(3, 4);
+      expect(a2).to.eql({
+        type: 'two',
+        payload: { dog: 3, egg: 4 },
+        meta: { zed: 1 }
+      });
+      expect(isFSA(a2)).to.be.true;
+      expect(a.two.toString()).to.equal('two');
+      const a3 = a.three('foo');
+      expect(a3).to.eql({
+        type: 'three',
+        payload: 'foo',
+        meta: { zed: 2 }
+      });
+      expect(isFSA(a3)).to.be.true;
+      expect(a.three.toString()).to.equal('three');
+    });
+  });
+
+  describe('createActions(actionMap, arrDefTypes)', () => {
+    it('returns an object with actions and default actions', () => {
+      const a = createActions(
+        {
+          one: (b, c) => ({ bat: b, cat: c }),
+          two: {
+            payload: (d, e) => ({ dog: d, egg: e }),
+            meta: (/* d, e */) => ({ zed: 1 })
+          },
+          three: {
+            meta: (/* f */) => ({ zed: 2 })
+          }
+        }, [
+          'four',
+          'five'
+        ]
+      );
+      expect(a).to.be.instanceOf(Object);
+      const a1 = a.one(1, 2);
+      expect(a1).to.eql({ type: 'one', payload: { bat: 1, cat: 2 } });
+      expect(isFSA(a1)).to.be.true;
+      expect(a.one.toString()).to.equal('one');
+      const a2 = a.two(3, 4);
+      expect(a2).to.eql({
+        type: 'two',
+        payload: { dog: 3, egg: 4 },
+        meta: { zed: 1 }
+      });
+      expect(isFSA(a2)).to.be.true;
+      expect(a.two.toString()).to.equal('two');
+      const a3 = a.three('foo');
+      expect(a3).to.eql({
+        type: 'three',
+        payload: 'foo',
+        meta: { zed: 2 }
+      });
+      expect(isFSA(a3)).to.be.true;
+      expect(a.three.toString()).to.equal('three');
+      const a4 = a.four(44);
+      expect(a4).to.eql({ type: 'four', payload: 44 });
+      expect(isFSA(a4)).to.be.true;
+      expect(a.four.toString()).to.equal('four');
+      const a5 = a.five(55);
+      expect(a5).to.eql({ type: 'five', payload: 55 });
+      expect(isFSA(a5)).to.be.true;
+      expect(a.five.toString()).to.equal('five');
+    });
+  });
+
+  describe('createActions(actionMap, optionMap)', () => {
+    it('returns an object with actions prefixed for each key', () => {
+      const a = createActions(
+        {
+          one: (b, c) => ({ bat: b, cat: c }),
+          two: {
+            payload: (d, e) => ({ dog: d, egg: e }),
+            meta: (/* d, e */) => ({ zed: 1 })
+          },
+          three: {
+            meta: (/* f */) => ({ zed: 2 })
+          }
+        },
+        {
+          prefix: 'ns/'
+        }
+      );
+      expect(a).to.be.instanceOf(Object);
+      const a1 = a.one(1, 2);
+      expect(a1).to.eql({ type: 'ns/one', payload: { bat: 1, cat: 2 } });
+      expect(isFSA(a1)).to.be.true;
+      expect(a.one.toString()).to.equal('ns/one');
+      const a2 = a.two(3, 4);
+      expect(a2).to.eql({
+        type: 'ns/two',
+        payload: { dog: 3, egg: 4 },
+        meta: { zed: 1 }
+      });
+      expect(isFSA(a2)).to.be.true;
+      expect(a.two.toString()).to.equal('ns/two');
+      const a3 = a.three('foo');
+      expect(a3).to.eql({
+        type: 'ns/three',
+        payload: 'foo',
+        meta: { zed: 2 }
+      });
+      expect(isFSA(a3)).to.be.true;
+      expect(a.three.toString()).to.equal('ns/three');
+    });
+  });
+
+  describe('createActions(arrDefTypes)', () => {
+    it('returns an object with default actions for each key', () => {
+      const a = createActions(['one', 'two']);
+      expect(a).to.be.instanceOf(Object);
+      const a1 = a.one({ foo: 'bar' });
+      expect(a1).to.eql({ type: 'one', payload: { foo: 'bar' } });
+      expect(isFSA(a1)).to.be.true;
+      expect(a.one.toString()).to.equal('one');
+      const a2 = a.two(42);
+      expect(a2).to.eql({ type: 'two', payload: 42 });
+      expect(isFSA(a2)).to.be.true;
+      expect(a.two.toString()).to.equal('two');
+    });
+  });
+
+  describe('createActions(arrDefTypes, optionMap)', () => {
+    it('returns an object w/default actions and prefixed type for each key ', () => {
+      const a = createActions(['one', 'two'], { prefix: 'ns/' });
+      expect(a).to.be.instanceOf(Object);
+      const a1 = a.one({ foo: 'bar' });
+      expect(a1).to.eql({ type: 'ns/one', payload: { foo: 'bar' } });
+      expect(isFSA(a1)).to.be.true;
+      expect(a.one.toString()).to.equal('ns/one');
+      const a2 = a.two(42);
+      expect(a2).to.eql({ type: 'ns/two', payload: 42 });
+      expect(isFSA(a2)).to.be.true;
+      expect(a.two.toString()).to.equal('ns/two');
+    });
+  });
+
+  describe('createActions(actionMap, arrDefTypes, optionMap)', () => {
+    it('returns an object w/actions and default actions w/prefixed types', () => {
+      const a = createActions(
+        {
+          one: (b, c) => ({ bat: b, cat: c }),
+          two: {
+            payload: (d, e) => ({ dog: d, egg: e }),
+            meta: (/* d, e */) => ({ zed: 1 })
+          },
+          three: {
+            meta: (/* f */) => ({ zed: 2 })
+          }
+        }, [
+          'four',
+          'five'
+        ], {
+          prefix: 'ns/'
+        }
+      );
+      expect(a).to.be.instanceOf(Object);
+      const a1 = a.one(1, 2);
+      expect(a1).to.eql({ type: 'ns/one', payload: { bat: 1, cat: 2 } });
+      expect(isFSA(a1)).to.be.true;
+      expect(a.one.toString()).to.equal('ns/one');
+      const a2 = a.two(3, 4);
+      expect(a2).to.eql({
+        type: 'ns/two',
+        payload: { dog: 3, egg: 4 },
+        meta: { zed: 1 }
+      });
+      expect(isFSA(a2)).to.be.true;
+      expect(a.two.toString()).to.equal('ns/two');
+      const a3 = a.three('foo');
+      expect(a3).to.eql({
+        type: 'ns/three',
+        payload: 'foo',
+        meta: { zed: 2 }
+      });
+      expect(isFSA(a3)).to.be.true;
+      expect(a.three.toString()).to.equal('ns/three');
+      const a4 = a.four(44);
+      expect(a4).to.eql({ type: 'ns/four', payload: 44 });
+      expect(isFSA(a4)).to.be.true;
+      expect(a.four.toString()).to.equal('ns/four');
+      const a5 = a.five(55);
+      expect(a5).to.eql({ type: 'ns/five', payload: 55 });
+      expect(isFSA(a5)).to.be.true;
+      expect(a.five.toString()).to.equal('ns/five');
+    });
+  });
+
+});

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -1,0 +1,59 @@
+import createAction from './createAction';
+
+function formatType(options, key) {
+  return `${options.prefix}${key}`;
+}
+
+/**
+   @param actionMap object optional - creates actions for each key,
+   using the value to determine the payload and meta creators. If
+   value is a fn, use it for the payloadCreator. If value is an
+   object use its `payload` and `meta` keys for payload and meta
+   creators.
+   @param arrayDefTypes array of strings optional
+   @param options object optional
+   @param options.prefix - string prefix all action types with, default ''
+   @returns object of actions
+*/
+export default function createActions(actionMap, arrDefTypes, options) {
+  // adjust for optional arguments
+  if (Array.isArray(actionMap)) { // actionMap not provided, shift
+    options = arrDefTypes;
+    arrDefTypes = actionMap;
+    actionMap = {};
+  }
+
+  if (!Array.isArray(arrDefTypes)) { // arrDefTypes not provided, shift
+    options = arrDefTypes;
+    arrDefTypes = [];
+  }
+
+  if (!options) { options = {}; }
+  if (!options.prefix) { options.prefix = ''; }
+
+  const mappedActions = Object.keys(actionMap).reduce(
+    (acc, key) => {
+      const type = formatType(options, key);
+      const action = actionMap[key];
+      let payloadCreator = undefined;
+      let metaCreator = undefined;
+      if (typeof action === 'function') {
+        payloadCreator = action;
+      } else if (typeof action === 'object') {
+        payloadCreator = action.payload;
+        metaCreator = action.meta;
+      }
+      acc[key] = createAction(type, payloadCreator, metaCreator);
+      return acc;
+    }, {});
+
+  // now combine in the default actions for arrDefTypes
+  const actions = arrDefTypes.reduce(
+    (acc, key) => {
+      const type = formatType(options, key);
+      acc[key] = createAction(type);
+      return acc;
+    }, mappedActions);
+
+  return actions;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import createAction from './createAction';
+import createActions from './createActions';
 import handleAction from './handleAction';
 import handleActions from './handleActions';
 
 export {
   createAction,
+  createActions,
   handleAction,
   handleActions
 };


### PR DESCRIPTION
The ideas for createActions were discussed in https://github.com/acdlite/redux-actions/pull/83 so this is a result of the discussions in that PR. The ideas had diverged a bit from the original authors work so I started with a fresh slate to implement the functionality.

Basically this is a partner to createAction like handleActions is to handleAction.

It cleans up the code and eliminates a bit of redundant typing that also could be a source of errors. 

One change from that #83 was that I went with an array for specifying default actions rather than having a variable set of arguments in the middle of the function. I don't know that typescript can handle that and I wanted the ability to pass an optionMap at the end that might be used to tweak the process. For instance, by passing in a { prefix: 'foo/' } then the createActions will automatically prefix they types with 'foo/'. I can imagine there may be other options that tweak how actions are created so it is nice to have a mechanism in the api to support extensions.

Here is the documentation from the readme with some examples:

### `createActions(?actionMap, ?arrayDefTypes, ?optionMap)`

Create multiple actions and return an object mapping from the type to the actionCreator. This eliminates some of the repetitiveness when creating many actions.

If `actionMap` is provided as first argument, an action will be created for each item in the map. The key will be used for the type. The value will be treated as follows:

 - if value is a function then it will be assumed to be the payloadCreator function
 - if value is an object then it will accept as its keys, payload and meta, both of which are functions that will serve as the payloadCreator and/or metaCreator. If payloadCreator is missing the default payloadCreator is used. If metaCreator is missing then it will not use one.
 - otherwise create a default actionCreator for the key type

If an array of string is provided as `arrayDefTypes` it will be used to create default actionCreators using the string for the action type.

If an `optionMap` object is supplied as last argument then it will adjust the options createActions uses in operation:

 - `prefix` - string, prefix all action types with this prefix, default ''

#### Example: simple default actions

```js
import { createActions } from 'redux-actions';
const a = createActions(['ONE', 'TWO', 'THREE']);

// is equivalent to
const a = {
  ONE: createAction('ONE'),
  TWO: createAction('TWO'),
  THREE: createAction('THREE')
;}
```

#### Example: simple default actions with prefix

```js
import { createActions } from 'redux-actions';
const a = createActions(['ONE', 'TWO', 'THREE'], { prefix: 'ns/');

// is equivalent to
const a = {
  ONE: createAction('ns/ONE'),
  TWO: createAction('ns/TWO'),
  THREE: createAction('ns/THREE')
;}
```

#### Example: using actionMap

```js
import { createActions } from 'redux-actions';
const a = createActions({
  ONE: (b, c) => ({ bar: b, cat: c }),  // payload creator
  TWO: {
    payload: (d, e) => [d, e]            // payload creator
    meta: (d, e) => ({ time: Date.now() }) // meta creator
  },
  THREE: {
    meta: f => ({ id: shortid() })
  }
});


// is equivalent to
const a = {
  ONE: createAction('ONE', (b, c) => ({ bar: b, cat: c })),
  TWO: createAction('TWO',
                    (d, e) => [d, e],
                    (d, e) => ({ time: Date.now() })),
  THREE: createAction('THREE',
                      undefined,  // used default payload creator
                      f => ({ id: shortid() }))
});
```

#### Example full createActions functionality

```js
import { createActions } from 'redux-actions';
const a = createActions(
  {
    ONE: (b, c) => ({ bar: b, cat: c }),  // payload creator
    TWO: {
      payload: (d, e) => [d, e]            // payload creator
      meta: (d, e) => ({ time: Date.now() }) // meta creator
    },
    THREE: {
      meta: f => ({ id: shortid() })
    }
  }, [ // arrayDefTypes creates defaultActions
    'FOUR',
    'FIVE',
    'SIX'
  ], {  // options
    prefix: 'ns/'
  }
);

// is equivalent to
const a = {
  ONE: createAction('ns/ONE', (b, c) => ({ bar: b, cat: c })),
  TWO: createAction('ns/TWO',
                    (d, e) => [d, e],
                    (d, e) => ({ time: Date.now() })),
  THREE: createAction('ns/THREE',
                      undefined,  // used default payload creator
                      f => ({ id: shortid() })),
  FOUR: createAction('ns/FOUR'),
  FIVE: createAction('ns/FIVE'),
  SIX: createAction('ns/SIX')
};
```


