### PR TITLE
Simplify return logic in handleActions; remove typeof check

### DIFF
--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -6,7 +6,5 @@ export default function handleActions(handlers, defaultState) {
   const reducers = ownKeys(handlers).map(type => handleAction(type, handlers[type]));
   const reducer = reduceReducers(...reducers);
 
-  return typeof defaultState !== 'undefined'
-    ? (state = defaultState, action) => reducer(state, action)
-    : reducer;
+  return (state = defaultState, action) => reducer(state, action);
 }


### PR DESCRIPTION
http://stackoverflow.com/a/4725697/2419669

>For undeclared variables, typeof foo will return the string literal "undefined", whereas the identity check foo === undefined would trigger the error "foo is not defined".
>
>For local variables (which you know are declared somewhere), no such error would occur, hence the identity check.

`defaultState` is declared as a parameter, so the `typeof` check is unnecessary (like [here](https://github.com/acdlite/redux-actions/blob/master/src/handleAction.js#L10)).