### PR TITLE
make "defaultState" a real default state

### DIFF
--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -2,6 +2,7 @@ import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
 import isSymbol from 'lodash/isSymbol';
+import isPlainObject from 'lodash/isPlainObject';
 
 export default function handleAction(type, reducers, defaultState) {
   const typeValue = isSymbol(type)
@@ -13,10 +14,17 @@ export default function handleAction(type, reducers, defaultState) {
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
+    let newState = state;
+    
+    // object will be the only situation that you may need to default assignment to happen.
+    if (isPlainObject(defaultState)) {
+      newState = Object.assign({}, state || {}, defaultState);
+    }
+    
     if (action.type !== typeValue) {
-      return state;
+      return newState;
     }
 
-    return (action.error === true ? throwReducer : nextReducer)(state, action);
+    return (action.error === true ? throwReducer : nextReducer)(newState, action);
   };
 }


### PR DESCRIPTION
it is common that we use Reducer to set a default state structure for every related action, and since through handleActions there's no way to create a common initial state for every action, I suggest instead of just relying on the ES6's default parameter feature, we use defaultState as a real default state.

And if defaultState is a non-object value, the ES6's default parameter feature should work well. Otherwise we use `Object.assign()` to do the trick.

A simple user case will be that I am implementing a reducer for a form logic, my state will include all the form fields, like below:

```json
{
  "values": {}
}
```

and I might want to define default fields:

```json
{
  "values": {
    "email": null,
    "name": null
  }
}
```

And to handle actions like 'EMAIL_CHANGE', I can just write:

```js
handleAction('EMAIL_CHANGE', (state, action) => {
    state.values.email = action.payload.email;
    return state;
}, {
  values: {
    email: null,
    name: null
  }
});
```

otherwise, I maybe need to do initialization for the state inside the reducer:

```js
handleAction('EMAIL_CHANGE', (state, action) => {
    state.values = state.values || { email: null, name: null };
    state.values.email = action.payload.email;
    return state;
}, {
  values: {
    email: null,
    name: null
  }
});
```