### PR TITLE
combineActions: handle multiple actions with the same reducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ const reducer = handleActions({
 
 ### `combineActions(...actionTypes)`
 
-Combine any number of action types or action creators.
+Combine any number of action types or action creators. `actionTypes` is a list of positional arguments which can be action type strings, symbols, or action creators.
 
-`actionTypes` is a list of positional arguments which can be action type strings, symbols, or action creators.
+This is useful for allowing your reducing multiple distinct actions with the same reducer.
 
 ```js
 const { increment, decrement } = createActions({

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ const reducer = handleActions({
 
 Combine any number of action types or action creators. `actionTypes` is a list of positional arguments which can be action type strings, symbols, or action creators.
 
-This is useful for allowing your reducing multiple distinct actions with the same reducer.
+This allows you to reduce multiple distinct actions with the same reducer.
 
 ```js
 const { increment, decrement } = createActions({

--- a/README.md
+++ b/README.md
@@ -96,19 +96,10 @@ This function exists because while action type strings can be joined with a conv
 const increment = createAction('INCREMENT', amount => ({ amount }))
 const decrement = createAction('DECREMENT', amount => ({ amount: -amount }))
 
-const reducer = handleAction(
-  combineActions(increment, decrement),
-  {
-    next(state, { payload: { amount } }) {
-      return { ...state, counter: state.counter + amount }
-    },
-
-    throw(state) {
-      return { ...state, counter: 0 }
-    },
-  },
-  { counter: 10 }
-)
+const reducer = handleAction(combineActions(increment, decrement), {
+  next: (state, { payload: { amount } }) => ({ ...state, counter: state.counter + amount }),
+  throw: state => ({ ...state, counter: 0 }),
+}, { counter: 10 })
 
 expect(reducer(undefined, increment(1)).to.deep.equal({ counter: 11 })
 expect(reducer(undefined, decrement(1)).to.deep.equal({ counter: 9 })
@@ -116,7 +107,7 @@ expect(reducer(undefined, increment(new Error)).to.deep.equal({ counter: 0 })
 expect(reducer(undefined, decrement(new Error)).to.deep.equal({ counter: 0 })
 ```
 
-This also works in when declaring reducers with the `next`/`throw` object format in `handleAction` and `handleActions`.
+This also works in when declaring multiple reducers with `handleActions`.
 
 ### `createActions(?actionsMap, ?...identityActions)`
 

--- a/README.md
+++ b/README.md
@@ -131,29 +131,6 @@ expect(actionThree(3)).to.deep.equal({
 });
 ```
 
-### `combineActions(...actionTypes)`
-
-Combine any number of action types or action creators.
-
-`actionTypes` is a list of positional arguments which can be action type strings, symbols, or action creators.
-
-```js
-const { increment, decrement } = createActions({
-  INCREMENT: amount => ({ amount }),
-  DECREMENT: amount => ({ amount: -amount }),
-})
-
-const reducer = handleAction(combineActions(increment, decrement), {
-  next: (state, { payload: { amount } }) => ({ ...state, counter: state.counter + amount }),
-  throw: state => ({ ...state, counter: 0 }),
-}, { counter: 10 })
-
-expect(reducer(undefined, increment(1)).to.deep.equal({ counter: 11 })
-expect(reducer(undefined, decrement(1)).to.deep.equal({ counter: 9 })
-expect(reducer(undefined, increment(new Error)).to.deep.equal({ counter: 0 })
-expect(reducer(undefined, decrement(new Error)).to.deep.equal({ counter: 0 })
-```
-
 ### `handleAction(type, reducer | reducerMap, ?defaultState)`
 
 ```js
@@ -201,6 +178,29 @@ const reducer = handleActions({
     counter: state.counter - action.payload
   })
 }, { counter: 0 });
+```
+
+### `combineActions(...actionTypes)`
+
+Combine any number of action types or action creators.
+
+`actionTypes` is a list of positional arguments which can be action type strings, symbols, or action creators.
+
+```js
+const { increment, decrement } = createActions({
+  INCREMENT: amount => ({ amount }),
+  DECREMENT: amount => ({ amount: -amount }),
+})
+
+const reducer = handleAction(combineActions(increment, decrement), {
+  next: (state, { payload: { amount } }) => ({ ...state, counter: state.counter + amount }),
+  throw: state => ({ ...state, counter: 0 }),
+}, { counter: 10 })
+
+expect(reducer(undefined, increment(1)).to.deep.equal({ counter: 11 })
+expect(reducer(undefined, decrement(1)).to.deep.equal({ counter: 9 })
+expect(reducer(undefined, increment(new Error)).to.deep.equal({ counter: 0 })
+expect(reducer(undefined, decrement(new Error)).to.deep.equal({ counter: 0 })
 ```
 
 ## Usage with middleware

--- a/README.md
+++ b/README.md
@@ -84,31 +84,6 @@ createAction('ADD_TODO')('Use Redux');
 
 `metaCreator` is an optional function that creates metadata for the payload. It receives the same arguments as the payload creator, but its result becomes the meta field of the resulting action. If `metaCreator` is undefined or not a function, the meta field is omitted.
 
-### `combineActions(...actionTypes)`
-
-Combine any number of action types or action creators.
-
-`actionTypes` is a list of positional arguments which can be action type strings or action creators.
-
-This function exists because while action type strings can be joined with a conventional delimiter, there is no obvious way for a library user to combine action creators.
-
-```js
-const { increment, decrement } = createActions({
-  INCREMENT: amount => ({ amount }),
-  DECREMENT: amount => ({ amount: -amount }),
-})
-
-const reducer = handleAction(combineActions(increment, decrement), {
-  next: (state, { payload: { amount } }) => ({ ...state, counter: state.counter + amount }),
-  throw: state => ({ ...state, counter: 0 }),
-}, { counter: 10 })
-
-expect(reducer(undefined, increment(1)).to.deep.equal({ counter: 11 })
-expect(reducer(undefined, decrement(1)).to.deep.equal({ counter: 9 })
-expect(reducer(undefined, increment(new Error)).to.deep.equal({ counter: 0 })
-expect(reducer(undefined, decrement(new Error)).to.deep.equal({ counter: 0 })
-```
-
 ### `createActions(?actionsMap, ?...identityActions)`
 
 ```js
@@ -154,6 +129,29 @@ expect(actionThree(3)).to.deep.equal({
   type: 'ACTION_THREE',
   payload: 3,
 });
+```
+
+### `combineActions(...actionTypes)`
+
+Combine any number of action types or action creators.
+
+`actionTypes` is a list of positional arguments which can be action type strings, symbols, or action creators.
+
+```js
+const { increment, decrement } = createActions({
+  INCREMENT: amount => ({ amount }),
+  DECREMENT: amount => ({ amount: -amount }),
+})
+
+const reducer = handleAction(combineActions(increment, decrement), {
+  next: (state, { payload: { amount } }) => ({ ...state, counter: state.counter + amount }),
+  throw: state => ({ ...state, counter: 0 }),
+}, { counter: 10 })
+
+expect(reducer(undefined, increment(1)).to.deep.equal({ counter: 11 })
+expect(reducer(undefined, decrement(1)).to.deep.equal({ counter: 9 })
+expect(reducer(undefined, increment(new Error)).to.deep.equal({ counter: 0 })
+expect(reducer(undefined, decrement(new Error)).to.deep.equal({ counter: 0 })
 ```
 
 ### `handleAction(type, reducer | reducerMap, ?defaultState)`

--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ Combine any number of action types or action creators.
 
 `actionTypes` is a variadic list of arguments which can be action type strings or action creators.
 
-This method exists because while action type strings can be joined with a conventional delimiter, there is no obvious way for a library user to combine action creators.
-
-The return value of this method is meant solely for use as action types in `handleAction` and `handleActions`.
+This function exists because while action type strings can be joined with a conventional delimiter, there is no obvious way for a library user to combine action creators.
 
 ```js
 const increment = createAction('INCREMENT', amount => ({ amount }))

--- a/README.md
+++ b/README.md
@@ -88,13 +88,15 @@ createAction('ADD_TODO')('Use Redux');
 
 Combine any number of action types or action creators.
 
-`actionTypes` is a variadic list of arguments which can be action type strings or action creators.
+`actionTypes` is a list of positional arguments which can be action type strings or action creators.
 
 This function exists because while action type strings can be joined with a conventional delimiter, there is no obvious way for a library user to combine action creators.
 
 ```js
-const increment = createAction('INCREMENT', amount => ({ amount }))
-const decrement = createAction('DECREMENT', amount => ({ amount: -amount }))
+const { increment, decrement } = createActions({
+  INCREMENT: amount => ({ amount }),
+  DECREMENT: amount => ({ amount: -amount }),
+})
 
 const reducer = handleAction(combineActions(increment, decrement), {
   next: (state, { payload: { amount } }) => ({ ...state, counter: state.counter + amount }),
@@ -106,8 +108,6 @@ expect(reducer(undefined, decrement(1)).to.deep.equal({ counter: 9 })
 expect(reducer(undefined, increment(new Error)).to.deep.equal({ counter: 0 })
 expect(reducer(undefined, decrement(new Error)).to.deep.equal({ counter: 0 })
 ```
-
-This also works in when declaring multiple reducers with `handleActions`.
 
 ### `createActions(?actionsMap, ?...identityActions)`
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,42 @@ createAction('ADD_TODO')('Use Redux');
 
 `metaCreator` is an optional function that creates metadata for the payload. It receives the same arguments as the payload creator, but its result becomes the meta field of the resulting action. If `metaCreator` is undefined or not a function, the meta field is omitted.
 
+### `combineActions(...actionTypes)`
+
+Combine any number of action types or action creators.
+
+`actionTypes` is a variadic list of arguments which can be action type strings or action creators.
+
+This method exists because while action type strings can be joined with a conventional delimiter, there is no obvious way for a library user to combine action creators.
+
+The return value of this method is meant solely for use as action types in `handleAction` and `handleActions`.
+
+```js
+const increment = createAction('INCREMENT', amount => ({ amount }))
+const decrement = createAction('DECREMENT', amount => ({ amount: -amount }))
+
+const reducer = handleAction(
+  combineActions(increment, decrement),
+  {
+    next(state, { payload: { amount } }) {
+      return { ...state, counter: state.counter + amount }
+    },
+
+    throw(state) {
+      return { ...state, counter: 0 }
+    },
+  },
+  { counter: 10 }
+)
+
+expect(reducer(undefined, increment(1)).to.deep.equal({ counter: 11 })
+expect(reducer(undefined, decrement(1)).to.deep.equal({ counter: 9 })
+expect(reducer(undefined, increment(new Error)).to.deep.equal({ counter: 0 })
+expect(reducer(undefined, decrement(new Error)).to.deep.equal({ counter: 0 })
+```
+
+This also works in when declaring reducers with the `next`/`throw` object format in `handleAction` and `handleActions`.
+
 ### `handleAction(type, reducer | reducerMap, ?defaultState)`
 
 Wraps a reducer so that it only handles Flux Standard Actions of a certain type.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && babel src --out-dir lib --ignore *-test.js",
     "clean": "rimraf lib",
-    "lint": "esw src --color --fix",
+    "lint": "esw src/**/* --color --fix",
     "lint:watch": "npm run lint -- --watch",
     "prepublish": "npm run lint && npm run test && npm run build",
     "test": "mocha --compilers js:babel-register src/**/*-test.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && babel src --out-dir lib --ignore *-test.js",
     "clean": "rimraf lib",
-    "lint": "esw src --color",
+    "lint": "esw src --color --fix",
     "lint:watch": "npm run lint -- --watch",
     "prepublish": "npm run lint && npm run test && npm run build",
     "test": "mocha --compilers js:babel-register src/**/*-test.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && babel src --out-dir lib --ignore *-test.js",
     "clean": "rimraf lib",
-    "lint": "esw src/**/* --color --fix",
+    "lint": "esw src/**/* --color",
     "lint:watch": "npm run lint -- --watch",
     "prepublish": "npm run lint && npm run test && npm run build",
     "test": "mocha --compilers js:babel-register src/**/*-test.js",

--- a/src/__tests__/combineActions-test.js
+++ b/src/__tests__/combineActions-test.js
@@ -4,10 +4,10 @@ import { expect } from 'chai';
 describe('combineActions', () => {
   it('should throw an error if any action is not a function or string', () => {
     expect(() => combineActions(1, 'ACTION_2'))
-      .to.throw(TypeError, 'Expected actions to be strings, symbols, or action creators');
+      .to.throw(TypeError, 'Expected action types to be strings, symbols, or action creators');
 
     expect(() => combineActions('ACTION_1', () => {}, null))
-      .to.throw(TypeError, 'Expected actions to be strings, symbols, or action creators');
+      .to.throw(TypeError, 'Expected action types to be strings, symbols, or action creators');
   });
 
   it('should accept action creators and action type strings', () => {

--- a/src/__tests__/combineActions-test.js
+++ b/src/__tests__/combineActions-test.js
@@ -1,4 +1,4 @@
-import { combineActions, createAction } from '../';
+import { combineActions, createActions } from '../';
 import { expect } from 'chai';
 
 describe('combineActions', () => {
@@ -11,7 +11,7 @@ describe('combineActions', () => {
   });
 
   it('should accept action creators and action type strings', () => {
-    const [action1, action2] = [createAction('ACTION_1'), createAction('ACTION_2')];
+    const { action1, action2 } = createActions('ACTION_1', 'ACTION_2')
 
     expect(() => combineActions('ACTION_1', 'ACTION_2'))
       .not.to.throw(Error);
@@ -22,7 +22,7 @@ describe('combineActions', () => {
   });
 
   it('should return a stringifiable object', () => {
-    const [action1, action2] = [createAction('ACTION_1'), createAction('ACTION_2')];
+    const { action1, action2 } = createActions('ACTION_1', 'ACTION_2')
 
     expect(combineActions('ACTION_1', 'ACTION_2')).to.respondTo('toString');
     expect(combineActions(action1, action2)).to.respondTo('toString');

--- a/src/__tests__/combineActions-test.js
+++ b/src/__tests__/combineActions-test.js
@@ -1,5 +1,5 @@
 import { combineActions, createAction } from '../';
-import { expect } from 'chai'
+import { expect } from 'chai';
 
 describe('combineActions', () => {
   it('should throw an error if any action is not a function or string', () => {
@@ -11,7 +11,7 @@ describe('combineActions', () => {
   });
 
   it('should accept action creators and action type strings', () => {
-    const [ action1, action2 ] = [ createAction('ACTION_1'), createAction('ACTION_2') ];
+    const [action1, action2] = [createAction('ACTION_1'), createAction('ACTION_2')];
 
     expect(() => combineActions('ACTION_1', 'ACTION_2'))
       .not.to.throw(Error);
@@ -22,7 +22,7 @@ describe('combineActions', () => {
   });
 
   it('should return a stringifiable object', () => {
-    const [ action1, action2 ] = [ createAction('ACTION_1'), createAction('ACTION_2') ];
+    const [action1, action2] = [createAction('ACTION_1'), createAction('ACTION_2')];
 
     expect(combineActions('ACTION_1', 'ACTION_2')).to.respondTo('toString');
     expect(combineActions(action1, action2)).to.respondTo('toString');

--- a/src/__tests__/combineActions-test.js
+++ b/src/__tests__/combineActions-test.js
@@ -3,13 +3,11 @@ import { expect } from 'chai'
 
 describe('combineActions', () => {
   it('should throw an error if any action is not a function or string', () => {
-    expect(
-      () => combineActions(1, 'ACTION_2')
-    ).to.throw(TypeError, 'Expected actions to be strings, symbols, or action creators');
+    expect(() => combineActions(1, 'ACTION_2'))
+      .to.throw(TypeError, 'Expected actions to be strings, symbols, or action creators');
 
-    expect(
-      () => combineActions('ACTION_1', () => {}, null)
-    ).to.throw(TypeError, 'Expected actions to be strings, symbols, or action creators');
+    expect(() => combineActions('ACTION_1', () => {}, null))
+      .to.throw(TypeError, 'Expected actions to be strings, symbols, or action creators');
   });
 
   it('should accept action creators and action type strings', () => {

--- a/src/__tests__/combineActions-test.js
+++ b/src/__tests__/combineActions-test.js
@@ -11,7 +11,7 @@ describe('combineActions', () => {
   });
 
   it('should accept action creators and action type strings', () => {
-    const { action1, action2 } = createActions('ACTION_1', 'ACTION_2')
+    const { action1, action2 } = createActions('ACTION_1', 'ACTION_2');
 
     expect(() => combineActions('ACTION_1', 'ACTION_2'))
       .not.to.throw(Error);
@@ -22,7 +22,7 @@ describe('combineActions', () => {
   });
 
   it('should return a stringifiable object', () => {
-    const { action1, action2 } = createActions('ACTION_1', 'ACTION_2')
+    const { action1, action2 } = createActions('ACTION_1', 'ACTION_2');
 
     expect(combineActions('ACTION_1', 'ACTION_2')).to.respondTo('toString');
     expect(combineActions(action1, action2)).to.respondTo('toString');

--- a/src/__tests__/combineActions-test.js
+++ b/src/__tests__/combineActions-test.js
@@ -1,0 +1,33 @@
+import { combineActions, createAction } from '../';
+import { expect } from 'chai'
+
+describe('combineActions', () => {
+  it('should throw an error if any action is not a function or string', () => {
+    expect(
+      () => combineActions(1, 'ACTION_2')
+    ).to.throw(TypeError, 'Expected actions to be strings, symbols, or action creators');
+
+    expect(
+      () => combineActions('ACTION_1', () => {}, null)
+    ).to.throw(TypeError, 'Expected actions to be strings, symbols, or action creators');
+  });
+
+  it('should accept action creators and action type strings', () => {
+    const [ action1, action2 ] = [ createAction('ACTION_1'), createAction('ACTION_2') ];
+
+    expect(() => combineActions('ACTION_1', 'ACTION_2'))
+      .not.to.throw(Error);
+    expect(() => combineActions(action1, action2))
+      .not.to.throw(Error);
+    expect(() => combineActions(action1, action2, 'ACTION_3'))
+      .not.to.throw(Error);
+  });
+
+  it('should return a stringifiable object', () => {
+    const [ action1, action2 ] = [ createAction('ACTION_1'), createAction('ACTION_2') ];
+
+    expect(combineActions('ACTION_1', 'ACTION_2')).to.respondTo('toString');
+    expect(combineActions(action1, action2)).to.respondTo('toString');
+    expect(combineActions(action1, action2, 'ACTION_3')).to.respondTo('toString');
+  });
+});

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -93,100 +93,100 @@ describe('handleAction()', () => {
       });
     });
   });
-  
+
   describe('with combined actions', () => {
     it('should handle combined actions in single reducer form', () => {
-      const action1 = createAction('ACTION_1')
+      const action1 = createAction('ACTION_1');
       const reducer = handleAction(
         combineActions(action1, 'ACTION_2', 'ACTION_3'),
         (state, action) => ({ ...state, number: action.payload })
-      )
-      
-      expect(reducer({ number: 0 }, action1(1))).to.deep.equal({ number: 1 })
-      expect(reducer({ number: 0 }, { type: 'ACTION_2', payload: 2 })).to.deep.equal({ number: 2 })
-      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 3 })).to.deep.equal({ number: 3 })
-    })
-    
+      );
+
+      expect(reducer({ number: 0 }, action1(1))).to.deep.equal({ number: 1 });
+      expect(reducer({ number: 0 }, { type: 'ACTION_2', payload: 2 })).to.deep.equal({ number: 2 });
+      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 3 })).to.deep.equal({ number: 3 });
+    });
+
     it('should handle combined actions in next/throw form', () => {
-      const action1 = createAction('ACTION_1')
+      const action1 = createAction('ACTION_1');
       const reducer = handleAction(
         combineActions(action1, 'ACTION_2', 'ACTION_3'),
         {
           next(state, action) {
-            return { ...state, number: action.payload }
-          },
+            return { ...state, number: action.payload };
+          }
         },
-      )
-      
-      expect(reducer({ number: 0 }, action1(1))).to.deep.equal({ number: 1 })
-      expect(reducer({ number: 0 }, { type: 'ACTION_2', payload: 2 })).to.deep.equal({ number: 2 })
-      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 3 })).to.deep.equal({ number: 3 })
-    })
-    
+      );
+
+      expect(reducer({ number: 0 }, action1(1))).to.deep.equal({ number: 1 });
+      expect(reducer({ number: 0 }, { type: 'ACTION_2', payload: 2 })).to.deep.equal({ number: 2 });
+      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 3 })).to.deep.equal({ number: 3 });
+    });
+
     it('should handle combined error actions', () => {
-      const action1 = createAction('ACTION_1')
+      const action1 = createAction('ACTION_1');
       const reducer = handleAction(
         combineActions(action1, 'ACTION_2', 'ACTION_3'),
         {
           next(state, action) {
-            return { ...state, payload: action.payload }
+            return { ...state, payload: action.payload };
           },
-          
+
           throw(state) {
-            return { ...state, threw: true }
-          },
+            return { ...state, threw: true };
+          }
         },
-      )
-      const error = new Error
-      
+      );
+      const error = new Error;
+
       expect(reducer({ number: 0 }, action1(error)))
-        .to.deep.equal({ number: 0, threw: true })
+        .to.deep.equal({ number: 0, threw: true });
       expect(reducer({ number: 0 }, { type: 'ACTION_2', payload: error, error: true }))
-        .to.deep.equal({ number: 0, threw: true })
+        .to.deep.equal({ number: 0, threw: true });
       expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: error, error: true }))
-        .to.deep.equal({ number: 0, threw: true })
-    })
-    
+        .to.deep.equal({ number: 0, threw: true });
+    });
+
     it('should return previous state if action is not one of the combined actions', () => {
       const reducer = handleAction(
         combineActions('ACTION_1', 'ACTION_2'),
         (state, { payload }) => ({ ...state, state: payload }),
-      )
-      
-      const state = { number: 0 }
-      
-      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.equal(state)
-      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.equal(state)
-    })
-    
+      );
+
+      const state = { number: 0 };
+
+      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.equal(state);
+      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.equal(state);
+    });
+
     it('should use the default state if the initial state is undefined', () => {
       const reducer = handleAction(
         combineActions('INCREMENT', 'DECREMENT'),
         (state, { payload }) => ({ ...state, counter: state.counter + payload }),
         { counter: 10 }
-      )
-      
-      expect(reducer(undefined, { type: 'INCREMENT', payload: +1 })).to.deep.equal({ counter: 11 })
-      expect(reducer(undefined, { type: 'DECREMENT', payload: -1 })).to.deep.equal({ counter: 9 })
-    })
-  
+      );
+
+      expect(reducer(undefined, { type: 'INCREMENT', payload: +1 })).to.deep.equal({ counter: 11 });
+      expect(reducer(undefined, { type: 'DECREMENT', payload: -1 })).to.deep.equal({ counter: 9 });
+    });
+
     it('should handle combined actions with symbols', () => {
-      const action1 = createAction('ACTION_1')
-      const action2 = Symbol('ACTION_2')
-      const action3 = createAction(Symbol('ACTION_3'))
+      const action1 = createAction('ACTION_1');
+      const action2 = Symbol('ACTION_2');
+      const action3 = createAction(Symbol('ACTION_3'));
       const reducer = handleAction(
         combineActions(action1, action2, action3),
         (state, action) => ({ ...state, number: action.payload })
-      )
-    
+      );
+
       expect(reducer({ number: 0 }, action1(1)))
-        .to.deep.equal({ number: 1 })
+        .to.deep.equal({ number: 1 });
       expect(reducer({ number: 0 }, { type: action2, payload: 2 }))
-        .to.deep.equal({ number: 2 })
+        .to.deep.equal({ number: 2 });
       // note that reference-checking here would produce false, since
       // Symbols are immutable, but this quirk should be harmless
       expect(reducer({ number: 0 }, { type: Symbol('ACTION_3'), payload: 3 }))
-        .to.deep.equal({ number: 3 })
-    })
-  })
+        .to.deep.equal({ number: 3 });
+    });
+  });
 });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -153,8 +153,10 @@ describe('handleAction()', () => {
         (state, { payload }) => ({ ...state, state: payload }),
       )
       
-      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 1 })).to.deep.equal({ number: 0 })
-      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 1 })).to.deep.equal({ number: 0 })
+      const state = { number: 0 }
+      
+      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.deep.equal(state)
+      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.deep.equal(state)
     })
     
     it('should use the default state if the initial state is undefined', () => {
@@ -168,7 +170,7 @@ describe('handleAction()', () => {
       expect(reducer(undefined, { type: 'DECREMENT', payload: -1 })).to.deep.equal({ counter: 9 })
     })
   
-    it('should handle combined symbols', () => {
+    it('should handle combined actions with symbols', () => {
       const action1 = createAction('ACTION_1')
       const action2 = Symbol('ACTION_2')
       const action3 = createAction(Symbol('ACTION_3'))
@@ -181,6 +183,8 @@ describe('handleAction()', () => {
         .to.deep.equal({ number: 1 })
       expect(reducer({ number: 0 }, { type: action2, payload: 2 }))
         .to.deep.equal({ number: 2 })
+      // note that reference-checking here would produce false, since
+      // Symbols are immutable, but this point should be harmless
       expect(reducer({ number: 0 }, { type: Symbol('ACTION_3'), payload: 3 }))
         .to.deep.equal({ number: 3 })
     })

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -155,8 +155,8 @@ describe('handleAction()', () => {
       
       const state = { number: 0 }
       
-      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.deep.equal(state)
-      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.deep.equal(state)
+      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.equal(state)
+      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.equal(state)
     })
     
     it('should use the default state if the initial state is undefined', () => {

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -156,7 +156,6 @@ describe('handleAction()', () => {
       const state = { number: 0 };
 
       expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.equal(state);
-      expect(reducer(state, { type: 'ACTION_3', payload: 1 })).to.equal(state);
     });
 
     it('should use the default state if the initial state is undefined', () => {

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { handleAction, createAction } from '../';
+import { handleAction, createAction, combineActions } from '../';
 
 describe('handleAction()', () => {
   const type = 'TYPE';
@@ -93,4 +93,93 @@ describe('handleAction()', () => {
       });
     });
   });
+  
+  describe('with combined actions', () => {
+    it('should handle combined actions in single reducer form', () => {
+      const action1 = createAction('ACTION_1')
+      const reducer = handleAction(
+        combineActions(action1, 'ACTION_2', 'ACTION_3'),
+        (state, action) => ({ ...state, number: action.payload })
+      )
+      
+      expect(reducer({ number: 0 }, action1(1))).to.deep.equal({ number: 1 })
+      expect(reducer({ number: 0 }, { type: 'ACTION_2', payload: 2 })).to.deep.equal({ number: 2 })
+      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 3 })).to.deep.equal({ number: 3 })
+    })
+    
+    it('should handle combined actions in next/throw form', () => {
+      const action1 = createAction('ACTION_1')
+      const reducer = handleAction(
+        combineActions(action1, 'ACTION_2', 'ACTION_3'),
+        {
+          next(state, action) {
+            return { ...state, number: action.payload }
+          },
+        },
+      )
+      
+      expect(reducer({ number: 0 }, action1(1))).to.deep.equal({ number: 1 })
+      expect(reducer({ number: 0 }, { type: 'ACTION_2', payload: 2 })).to.deep.equal({ number: 2 })
+      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 3 })).to.deep.equal({ number: 3 })
+    })
+    
+    it('should handle combined error actions', () => {
+      const action1 = createAction('ACTION_1')
+      const reducer = handleAction(
+        combineActions(action1, 'ACTION_2', 'ACTION_3'),
+        {
+          next(state, action) {
+            return { ...state, payload: action.payload }
+          },
+          
+          throw(state) {
+            return { ...state, threw: true }
+          },
+        },
+      )
+      const error = new Error
+      
+      expect(reducer({ number: 0 }, action1(error)))
+        .to.deep.equal({ number: 0, threw: true })
+      expect(reducer({ number: 0 }, { type: 'ACTION_2', payload: error, error: true }))
+        .to.deep.equal({ number: 0, threw: true })
+      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: error, error: true }))
+        .to.deep.equal({ number: 0, threw: true })
+    })
+    
+    it('should return the previous state if the action type is not any of the combined actions', () => {
+      const reducer = handleAction(
+        combineActions('ACTION_1', 'ACTION_2'),
+        (state, { payload }) => ({ ...state, state: payload }),
+      )
+      
+      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 1 })).to.deep.equal({ number: 0 })
+      expect(reducer({ number: 0 }, { type: 'ACTION_3', payload: 1 })).to.deep.equal({ number: 0 })
+    })
+    
+    it('should use the default state if the initial state is undefined', () => {
+      const reducer = handleAction(
+        combineActions('INCREMENT', 'DECREMENT'),
+        (state, { payload }) => ({ ...state, counter: state.counter + payload }),
+        { counter: 10 }
+      )
+      
+      expect(reducer(undefined, { type: 'INCREMENT', payload: +1 })).to.deep.equal({ counter: 11 })
+      expect(reducer(undefined, { type: 'DECREMENT', payload: -1 })).to.deep.equal({ counter: 9 })
+    })
+  
+    it('should handle combined symbols', () => {
+      const action1 = createAction('ACTION_1')
+      const action2 = Symbol('ACTION_2')
+      const action3 = createAction(Symbol('ACTION_3'))
+      const reducer = handleAction(
+        combineActions(action1, action2, action3),
+        (state, action) => ({ ...state, number: action.payload })
+      )
+    
+      expect(reducer({ number: 0 }, action1(1))).to.deep.equal({ number: 1 })
+      expect(reducer({ number: 0 }, { type: action2, payload: 2 })).to.deep.equal({ number: 2 })
+      expect(reducer({ number: 0 }, { type: Symbol('ACTION_3'), payload: 3 })).to.deep.equal({ number: 3 })
+    })
+  })
 });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -147,7 +147,7 @@ describe('handleAction()', () => {
         .to.deep.equal({ number: 0, threw: true })
     })
     
-    it('should return the previous state if the action type is not any of the combined actions', () => {
+    it('should return previous state if action is not one of the combined actions', () => {
       const reducer = handleAction(
         combineActions('ACTION_1', 'ACTION_2'),
         (state, { payload }) => ({ ...state, state: payload }),
@@ -177,9 +177,12 @@ describe('handleAction()', () => {
         (state, action) => ({ ...state, number: action.payload })
       )
     
-      expect(reducer({ number: 0 }, action1(1))).to.deep.equal({ number: 1 })
-      expect(reducer({ number: 0 }, { type: action2, payload: 2 })).to.deep.equal({ number: 2 })
-      expect(reducer({ number: 0 }, { type: Symbol('ACTION_3'), payload: 3 })).to.deep.equal({ number: 3 })
+      expect(reducer({ number: 0 }, action1(1)))
+        .to.deep.equal({ number: 1 })
+      expect(reducer({ number: 0 }, { type: action2, payload: 2 }))
+        .to.deep.equal({ number: 2 })
+      expect(reducer({ number: 0 }, { type: Symbol('ACTION_3'), payload: 3 }))
+        .to.deep.equal({ number: 3 })
     })
   })
 });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -124,14 +124,11 @@ describe('handleAction()', () => {
 
     it('should handle combined actions in next/throw form', () => {
       const action1 = createAction('ACTION_1');
-      const reducer = handleAction(
-        combineActions(action1, 'ACTION_2', 'ACTION_3'),
-        {
-          next(state, action) {
-            return { ...state, number: action.payload };
-          }
-        },
-      );
+      const reducer = handleAction(combineActions(action1, 'ACTION_2', 'ACTION_3'), {
+        next(state, action) {
+          return { ...state, number: action.payload };
+        }
+      });
 
       expect(reducer({ number: 0 }, action1(1))).to.deep.equal({ number: 1 });
       expect(reducer({ number: 0 }, { type: 'ACTION_2', payload: 2 })).to.deep.equal({ number: 2 });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -184,7 +184,7 @@ describe('handleAction()', () => {
       expect(reducer({ number: 0 }, { type: action2, payload: 2 }))
         .to.deep.equal({ number: 2 })
       // note that reference-checking here would produce false, since
-      // Symbols are immutable, but this point should be harmless
+      // Symbols are immutable, but this quirk should be harmless
       expect(reducer({ number: 0 }, { type: Symbol('ACTION_3'), payload: 3 }))
         .to.deep.equal({ number: 3 })
     })

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -81,7 +81,8 @@ describe('handleActions', () => {
     
     expect(reducer({ counter: 10 }, increment(5))).to.deep.equal({ counter: 15 })
     expect(reducer({ counter: 10 }, decrement(5))).to.deep.equal({ counter: 5 })
-    expect(reducer({ counter: 10 }, { type: 'NOT_TYPE', payload: 1000 })).to.deep.equal({ counter: 10 })
+    expect(reducer({ counter: 10 }, { type: 'NOT_TYPE', payload: 1000 }))
+      .to.deep.equal({ counter: 10 })
     expect(reducer(undefined, increment(5))).to.deep.equal({ counter: -5 })
   })
   
@@ -105,7 +106,8 @@ describe('handleActions', () => {
     // non-errors
     expect(reducer({ counter: 10 }, increment(5))).to.deep.equal({ counter: 15 })
     expect(reducer({ counter: 10 }, decrement(5))).to.deep.equal({ counter: 5 })
-    expect(reducer({ counter: 10 }, { type: 'NOT_TYPE', payload: 1000 })).to.deep.equal({ counter: 10 })
+    expect(reducer({ counter: 10 }, { type: 'NOT_TYPE', payload: 1000 }))
+      .to.deep.equal({ counter: 10 })
     expect(reducer(undefined, increment(5))).to.deep.equal({ counter: -5 })
     
     // errors

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -69,26 +69,29 @@ describe('handleActions', () => {
       });
   });
   
-  it('should accept combined actions as action types in unified reducer form', () => {
+  it('should accept combined actions as action types in single reducer form', () => {
     const increment = createAction('INCREMENT', amount => ({ amount }))
     const decrement = createAction('DECREMENT', amount => ({ amount: -amount }))
+    
+    const initialState = { counter: 10 }
     
     const reducer = handleActions({
       [combineActions(increment, decrement)](state, { payload: { amount } }) {
         return { ...state, counter: state.counter + amount }
       },
-    }, { counter: -10 })
+    }, initialState)
     
-    expect(reducer({ counter: 10 }, increment(5))).to.deep.equal({ counter: 15 })
-    expect(reducer({ counter: 10 }, decrement(5))).to.deep.equal({ counter: 5 })
-    expect(reducer({ counter: 10 }, { type: 'NOT_TYPE', payload: 1000 }))
-      .to.deep.equal({ counter: 10 })
-    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: -5 })
+    expect(reducer(initialState, increment(5))).to.deep.equal({ counter: 15 })
+    expect(reducer(initialState, decrement(5))).to.deep.equal({ counter: 5 })
+    expect(reducer(initialState, { type: 'NOT_TYPE', payload: 1000 })).to.equal(initialState)
+    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 15 })
   })
   
   it('should accept combined actions as action types in the next/throw form', () => {
     const increment = createAction('INCREMENT', amount => ({ amount }))
     const decrement = createAction('DECREMENT', amount => ({ amount: -amount }))
+    
+    const initialState = { counter: 10 }
     
     const reducer = handleActions({
       [combineActions(increment, decrement)]: {
@@ -100,22 +103,21 @@ describe('handleActions', () => {
           return { ...state, counter: 0 }
         },
       },
-    }, { counter: -10 })
+    }, initialState)
     const error = new Error
     
     // non-errors
-    expect(reducer({ counter: 10 }, increment(5))).to.deep.equal({ counter: 15 })
-    expect(reducer({ counter: 10 }, decrement(5))).to.deep.equal({ counter: 5 })
-    expect(reducer({ counter: 10 }, { type: 'NOT_TYPE', payload: 1000 }))
-      .to.deep.equal({ counter: 10 })
-    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: -5 })
+    expect(reducer(initialState, increment(5))).to.deep.equal({ counter: 15 })
+    expect(reducer(initialState, decrement(5))).to.deep.equal({ counter: 5 })
+    expect(reducer(initialState, { type: 'NOT_TYPE', payload: 1000 })).to.equal(initialState)
+    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 15 })
     
     // errors
     expect(
-      reducer({ counter: 10 }, { type: 'INCREMENT', payload: error, error: true })
+      reducer(initialState, { type: 'INCREMENT', payload: error, error: true })
     ).to.deep.equal({ counter: 0 })
     expect(
-      reducer({ counter: 10 }, decrement(error))
+      reducer(initialState, decrement(error))
     ).to.deep.equal({ counter: 0 })
   })
 });

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -68,56 +68,56 @@ describe('handleActions', () => {
         counter: 10
       });
   });
-  
+
   it('should accept combined actions as action types in single reducer form', () => {
-    const increment = createAction('INCREMENT', amount => ({ amount }))
-    const decrement = createAction('DECREMENT', amount => ({ amount: -amount }))
-    
-    const initialState = { counter: 10 }
-    
+    const increment = createAction('INCREMENT', amount => ({ amount }));
+    const decrement = createAction('DECREMENT', amount => ({ amount: -amount }));
+
+    const initialState = { counter: 10 };
+
     const reducer = handleActions({
       [combineActions(increment, decrement)](state, { payload: { amount } }) {
-        return { ...state, counter: state.counter + amount }
-      },
-    }, initialState)
-    
-    expect(reducer(initialState, increment(5))).to.deep.equal({ counter: 15 })
-    expect(reducer(initialState, decrement(5))).to.deep.equal({ counter: 5 })
-    expect(reducer(initialState, { type: 'NOT_TYPE', payload: 1000 })).to.equal(initialState)
-    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 15 })
-  })
-  
+        return { ...state, counter: state.counter + amount };
+      }
+    }, initialState);
+
+    expect(reducer(initialState, increment(5))).to.deep.equal({ counter: 15 });
+    expect(reducer(initialState, decrement(5))).to.deep.equal({ counter: 5 });
+    expect(reducer(initialState, { type: 'NOT_TYPE', payload: 1000 })).to.equal(initialState);
+    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 15 });
+  });
+
   it('should accept combined actions as action types in the next/throw form', () => {
-    const increment = createAction('INCREMENT', amount => ({ amount }))
-    const decrement = createAction('DECREMENT', amount => ({ amount: -amount }))
-    
-    const initialState = { counter: 10 }
-    
+    const increment = createAction('INCREMENT', amount => ({ amount }));
+    const decrement = createAction('DECREMENT', amount => ({ amount: -amount }));
+
+    const initialState = { counter: 10 };
+
     const reducer = handleActions({
       [combineActions(increment, decrement)]: {
         next(state, { payload: { amount } }) {
-          return { ...state, counter: state.counter + amount }
+          return { ...state, counter: state.counter + amount };
         },
-        
+
         throw(state) {
-          return { ...state, counter: 0 }
-        },
-      },
-    }, initialState)
-    const error = new Error
-    
+          return { ...state, counter: 0 };
+        }
+      }
+    }, initialState);
+    const error = new Error;
+
     // non-errors
-    expect(reducer(initialState, increment(5))).to.deep.equal({ counter: 15 })
-    expect(reducer(initialState, decrement(5))).to.deep.equal({ counter: 5 })
-    expect(reducer(initialState, { type: 'NOT_TYPE', payload: 1000 })).to.equal(initialState)
-    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 15 })
-    
+    expect(reducer(initialState, increment(5))).to.deep.equal({ counter: 15 });
+    expect(reducer(initialState, decrement(5))).to.deep.equal({ counter: 5 });
+    expect(reducer(initialState, { type: 'NOT_TYPE', payload: 1000 })).to.equal(initialState);
+    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 15 });
+
     // errors
     expect(
       reducer(initialState, { type: 'INCREMENT', payload: error, error: true })
-    ).to.deep.equal({ counter: 0 })
+    ).to.deep.equal({ counter: 0 });
     expect(
       reducer(initialState, decrement(error))
-    ).to.deep.equal({ counter: 0 })
-  })
+    ).to.deep.equal({ counter: 0 });
+  });
 });

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { handleActions, createAction } from '../';
+import { handleActions, createAction, combineActions } from '../';
 
 describe('handleActions', () => {
   it('create a single handler from a map of multiple action handlers', () => {
@@ -68,4 +68,52 @@ describe('handleActions', () => {
         counter: 10
       });
   });
+  
+  it('should accept combined actions as action types in unified reducer form', () => {
+    const increment = createAction('INCREMENT', amount => ({ amount }))
+    const decrement = createAction('DECREMENT', amount => ({ amount: -amount }))
+    
+    const reducer = handleActions({
+      [combineActions(increment, decrement)](state, { payload: { amount } }) {
+        return { ...state, counter: state.counter + amount }
+      },
+    }, { counter: -10 })
+    
+    expect(reducer({ counter: 10 }, increment(5))).to.deep.equal({ counter: 15 })
+    expect(reducer({ counter: 10 }, decrement(5))).to.deep.equal({ counter: 5 })
+    expect(reducer({ counter: 10 }, { type: 'NOT_TYPE', payload: 1000 })).to.deep.equal({ counter: 10 })
+    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: -5 })
+  })
+  
+  it('should accept combined actions as action types in the next/throw form', () => {
+    const increment = createAction('INCREMENT', amount => ({ amount }))
+    const decrement = createAction('DECREMENT', amount => ({ amount: -amount }))
+    
+    const reducer = handleActions({
+      [combineActions(increment, decrement)]: {
+        next(state, { payload: { amount } }) {
+          return { ...state, counter: state.counter + amount }
+        },
+        
+        throw(state) {
+          return { ...state, counter: 0 }
+        },
+      },
+    }, { counter: -10 })
+    const error = new Error
+    
+    // non-errors
+    expect(reducer({ counter: 10 }, increment(5))).to.deep.equal({ counter: 15 })
+    expect(reducer({ counter: 10 }, decrement(5))).to.deep.equal({ counter: 5 })
+    expect(reducer({ counter: 10 }, { type: 'NOT_TYPE', payload: 1000 })).to.deep.equal({ counter: 10 })
+    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: -5 })
+    
+    // errors
+    expect(
+      reducer({ counter: 10 }, { type: 'INCREMENT', payload: error, error: true })
+    ).to.deep.equal({ counter: 0 })
+    expect(
+      reducer({ counter: 10 }, decrement(error))
+    ).to.deep.equal({ counter: 0 })
+  })
 });

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -4,7 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import toString from 'lodash/toString';
 import isSymbol from 'lodash/isSymbol';
 
-export const ACTION_TYPE_DELIMITER = '|redux-action-delimiter|';
+export const ACTION_TYPE_DELIMITER = '||';
 
 function isValidActionType(actionType) {
   return isString(actionType) || isFunction(actionType) || isSymbol(actionType);

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -1,0 +1,29 @@
+import isString from 'lodash/isString';
+import isFunction from 'lodash/isFunction';
+import isEmpty from 'lodash/isEmpty';
+
+export const FSA_TYPE_DELIMITER = '|fsa-type-delimiter|';
+
+export default function combineActions(...actions) {
+  if (isEmpty(actions)|| !actions.every(isValidActionType)) {
+    throw new TypeError('Expected each argument to be a string action type or an action creator');
+  }
+
+  const combinedActionsString = actions.map(type => type.toString()).join(FSA_TYPE_DELIMITER);
+
+  return Object.create(null, {
+    toString: {
+      enumerable: true,
+      writable: false,
+      configurable: false,
+      value() {
+        return combinedActionsString;
+      }
+    }
+  });
+}
+
+function isValidActionType(action) {
+  return isString(action) || isFunction(action);
+}
+

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -14,14 +14,7 @@ export default function combineActions(...actions) {
   const combinedActionsString = actions.map(toString).join(ACTION_DELIMITER);
 
   return Object.create(null, {
-    toString: {
-      enumerable: true,
-      writable: false,
-      configurable: false,
-      value() {
-        return combinedActionsString;
-      }
-    }
+    toString: { enumerable: true, value: () => combinedActionsString }
   });
 }
 

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -18,7 +18,7 @@ export default function combineActions(...actionsTypes) {
 
 function isValidActionTypes(actionTypes) {
   if (isEmpty(actionTypes)) {
-    return false
+    return false;
   }
   return actionTypes.every(isValidActionType);
 }

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -6,15 +6,15 @@ import isSymbol from 'lodash/isSymbol';
 
 export const ACTION_TYPE_DELIMITER = '|redux-action-delimiter|';
 
+function isValidActionType(actionType) {
+  return isString(actionType) || isFunction(actionType) || isSymbol(actionType);
+}
+
 function isValidActionTypes(actionTypes) {
   if (isEmpty(actionTypes)) {
     return false;
   }
   return actionTypes.every(isValidActionType);
-}
-
-function isValidActionType(actionType) {
-  return isString(actionType) || isFunction(actionType) || isSymbol(actionType);
 }
 
 export default function combineActions(...actionsTypes) {

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -20,6 +20,9 @@ function isValidActionTypes(actionTypes) {
   if (isEmpty(actionTypes)) {
     return false
   }
-  return actionTypes.every(actionType => isString(actionType) || isFunction(actionType) || isSymbol(actionType));
+  return actionTypes.every(isValidActionType);
 }
 
+function isValidActionType(actionType) {
+  return isString(actionType) || isFunction(actionType) || isSymbol(actionType);
+}

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -5,7 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 export const FSA_TYPE_DELIMITER = '|fsa-type-delimiter|';
 
 export default function combineActions(...actions) {
-  if (isEmpty(actions)|| !actions.every(isValidActionType)) {
+  if (isEmpty(actions) || !actions.every(isValidActionType)) {
     throw new TypeError('Expected each argument to be a string action type or an action creator');
   }
 

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -6,19 +6,22 @@ import isSymbol from 'lodash/isSymbol';
 
 export const ACTION_TYPE_DELIMITER = '|redux-action-delimiter|';
 
-export default function combineActions(...actions) {
-  if (isEmpty(actions) || !actions.every(isValidActionType)) {
-    throw new TypeError('Expected actions to be strings, symbols, or action creators');
+export default function combineActions(...actionsTypes) {
+  if (!isValidActionTypes(actionsTypes)) {
+    throw new TypeError('Expected action types to be strings, symbols, or action creators');
   }
 
-  const combinedActionsString = actions.map(toString).join(ACTION_TYPE_DELIMITER);
+  const combinedActionType = actionsTypes.map(toString).join(ACTION_TYPE_DELIMITER);
 
   return Object.create(null, {
-    toString: { enumerable: true, value: () => combinedActionsString }
+    toString: { enumerable: true, value: () => combinedActionType }
   });
 }
 
-function isValidActionType(action) {
-  return isString(action) || isFunction(action) || isSymbol(action);
+function isValidActionTypes(actionTypes) {
+  if (isEmpty(actionTypes)) {
+    return false
+  }
+  return actionTypes.every(actionType => isString(actionType) || isFunction(actionType) || isSymbol(actionType));
 }
 

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -1,6 +1,7 @@
 import isString from 'lodash/isString';
 import isFunction from 'lodash/isFunction';
 import isEmpty from 'lodash/isEmpty';
+import toString from 'lodash/toString';
 
 export const FSA_TYPE_DELIMITER = '|fsa-type-delimiter|';
 
@@ -9,7 +10,7 @@ export default function combineActions(...actions) {
     throw new TypeError('Expected each argument to be a string action type or an action creator');
   }
 
-  const combinedActionsString = actions.map(type => type.toString()).join(FSA_TYPE_DELIMITER);
+  const combinedActionsString = actions.map(toString).join(FSA_TYPE_DELIMITER);
 
   return Object.create(null, {
     toString: {

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -6,16 +6,6 @@ import isSymbol from 'lodash/isSymbol';
 
 export const ACTION_TYPE_DELIMITER = '|redux-action-delimiter|';
 
-export default function combineActions(...actionsTypes) {
-  if (!isValidActionTypes(actionsTypes)) {
-    throw new TypeError('Expected action types to be strings, symbols, or action creators');
-  }
-
-  const combinedActionType = actionsTypes.map(toString).join(ACTION_TYPE_DELIMITER);
-
-  return { toString: () => combinedActionType };
-}
-
 function isValidActionTypes(actionTypes) {
   if (isEmpty(actionTypes)) {
     return false;
@@ -25,4 +15,14 @@ function isValidActionTypes(actionTypes) {
 
 function isValidActionType(actionType) {
   return isString(actionType) || isFunction(actionType) || isSymbol(actionType);
+}
+
+export default function combineActions(...actionsTypes) {
+  if (!isValidActionTypes(actionsTypes)) {
+    throw new TypeError('Expected action types to be strings, symbols, or action creators');
+  }
+
+  const combinedActionType = actionsTypes.map(toString).join(ACTION_TYPE_DELIMITER);
+
+  return { toString: () => combinedActionType };
 }

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -3,14 +3,14 @@ import isFunction from 'lodash/isFunction';
 import isEmpty from 'lodash/isEmpty';
 import toString from 'lodash/toString';
 
-export const FSA_TYPE_DELIMITER = '|fsa-type-delimiter|';
+export const ACTION_DELIMITER = '|redux-action-delimiter|';
 
 export default function combineActions(...actions) {
   if (isEmpty(actions) || !actions.every(isValidActionType)) {
     throw new TypeError('Expected each argument to be a string action type or an action creator');
   }
 
-  const combinedActionsString = actions.map(toString).join(FSA_TYPE_DELIMITER);
+  const combinedActionsString = actions.map(toString).join(ACTION_DELIMITER);
 
   return Object.create(null, {
     toString: {

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -4,14 +4,14 @@ import isEmpty from 'lodash/isEmpty';
 import toString from 'lodash/toString';
 import isSymbol from 'lodash/isSymbol';
 
-export const ACTION_DELIMITER = '|redux-action-delimiter|';
+export const ACTION_TYPE_DELIMITER = '|redux-action-delimiter|';
 
 export default function combineActions(...actions) {
   if (isEmpty(actions) || !actions.every(isValidActionType)) {
     throw new TypeError('Expected actions to be strings, symbols, or action creators');
   }
 
-  const combinedActionsString = actions.map(toString).join(ACTION_DELIMITER);
+  const combinedActionsString = actions.map(toString).join(ACTION_TYPE_DELIMITER);
 
   return Object.create(null, {
     toString: { enumerable: true, value: () => combinedActionsString }

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -2,12 +2,13 @@ import isString from 'lodash/isString';
 import isFunction from 'lodash/isFunction';
 import isEmpty from 'lodash/isEmpty';
 import toString from 'lodash/toString';
+import isSymbol from 'lodash/isSymbol';
 
 export const ACTION_DELIMITER = '|redux-action-delimiter|';
 
 export default function combineActions(...actions) {
   if (isEmpty(actions) || !actions.every(isValidActionType)) {
-    throw new TypeError('Expected each argument to be a string action type or an action creator');
+    throw new TypeError('Expected actions to be strings, symbols, or action creators');
   }
 
   const combinedActionsString = actions.map(toString).join(ACTION_DELIMITER);
@@ -25,6 +26,6 @@ export default function combineActions(...actions) {
 }
 
 function isValidActionType(action) {
-  return isString(action) || isFunction(action);
+  return isString(action) || isFunction(action) || isSymbol(action);
 }
 

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -13,9 +13,7 @@ export default function combineActions(...actionsTypes) {
 
   const combinedActionType = actionsTypes.map(toString).join(ACTION_TYPE_DELIMITER);
 
-  return Object.create(null, {
-    toString: { enumerable: true, value: () => combinedActionType }
-  });
+  return { toString: () => combinedActionType };
 }
 
 function isValidActionTypes(actionTypes) {

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -29,7 +29,7 @@ export default function createAction(type, payloadCreator, metaCreator) {
     return action;
   };
 
-  actionHandler.toString = () => type;
+  actionHandler.toString = () => type.toString();
 
   return actionHandler;
 }

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -3,24 +3,24 @@ import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
 import includes from 'lodash/includes';
 import isSymbol from 'lodash/isSymbol';
-import { FSA_TYPE_DELIMITER } from './combineActions';
+import { ACTION_DELIMITER } from './combineActions';
 
-export default function handleAction(handlee, reducers, defaultState) {
-  const typeValue = isSymbol(handlee)
-    ? handlee
-    : handlee.toString().split(FSA_TYPE_DELIMITER);
+export default function handleAction(type, reducers, defaultState) {
+  const typeValue = isSymbol(type)
+    ? type
+    : type.toString().split(ACTION_DELIMITER);
 
   const [nextReducer, throwReducer] = isFunction(reducers)
     ? [reducers, reducers]
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
-    const { type } = action;
+    const actionType = action.type;
     if (isSymbol(typeValue)) {
-      if (type !== typeValue) {
+      if (actionType !== typeValue) {
         return state;
       }
-    } else if (!includes(typeValue, type)) {
+    } else if (!includes(typeValue, actionType)) {
       return state;
     }
     return (action.error === true ? throwReducer : nextReducer)(state, action);

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,6 +1,7 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
+import includes from 'lodash/includes';
 import { ACTION_TYPE_DELIMITER } from './combineActions';
 
 export default function handleAction(actionType, reducers, defaultState) {
@@ -11,7 +12,7 @@ export default function handleAction(actionType, reducers, defaultState) {
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
-    if (!actionTypes.includes(action.type.toString())) {
+    if (!includes(actionTypes, action.type.toString())) {
       return state;
     }
 

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,18 +1,18 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
-import includes from 'lodash/includes';
-import { ACTION_DELIMITER } from './combineActions';
+import includes from 'lodash/includes'
+import { ACTION_TYPE_DELIMITER } from './combineActions';
 
-export default function handleAction(type, reducers, defaultState) {
-  const typeValue = type.toString().split(ACTION_DELIMITER);
+export default function handleAction(actionType, reducers, defaultState) {
+  const actionTypes = actionType.toString().split(ACTION_TYPE_DELIMITER);
 
   const [nextReducer, throwReducer] = isFunction(reducers)
     ? [reducers, reducers]
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
-    if (!includes(typeValue, action.type.toString())) {
+    if (!includes(actionTypes, action.type.toString())) {
       return state;
     }
 

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -15,6 +15,7 @@ export default function handleAction(type, reducers, defaultState) {
     if (!includes(typeValue, action.type.toString())) {
       return state;
     }
+
     return (action.error === true ? throwReducer : nextReducer)(state, action);
   };
 }

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,22 +1,28 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
+import includes from 'lodash/includes';
 import isSymbol from 'lodash/isSymbol';
+import { FSA_TYPE_DELIMITER } from './combineActions';
 
-export default function handleAction(type, reducers, defaultState) {
-  const typeValue = isSymbol(type)
-    ? type
-    : type.toString();
+export default function handleAction(handlee, reducers, defaultState) {
+  const typeValue = isSymbol(handlee)
+    ? handlee
+    : handlee.toString().split(FSA_TYPE_DELIMITER);
 
   const [nextReducer, throwReducer] = isFunction(reducers)
     ? [reducers, reducers]
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
-    if (action.type !== typeValue) {
+    const { type } = action;
+    if (isSymbol(typeValue)) {
+      if (type !== typeValue) {
+        return state;
+      }
+    } else if (!includes(typeValue, type)) {
       return state;
     }
-
     return (action.error === true ? throwReducer : nextReducer)(state, action);
   };
 }

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,7 +1,7 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
-import includes from 'lodash/includes'
+import includes from 'lodash/includes';
 import { ACTION_TYPE_DELIMITER } from './combineActions';
 
 export default function handleAction(actionType, reducers, defaultState) {

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,7 +1,6 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
-import includes from 'lodash/includes';
 import { ACTION_TYPE_DELIMITER } from './combineActions';
 
 export default function handleAction(actionType, reducers, defaultState) {
@@ -12,7 +11,7 @@ export default function handleAction(actionType, reducers, defaultState) {
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
-    if (!includes(actionTypes, action.type.toString())) {
+    if (!actionTypes.includes(action.type.toString())) {
       return state;
     }
 

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -2,25 +2,17 @@ import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
 import includes from 'lodash/includes';
-import isSymbol from 'lodash/isSymbol';
 import { ACTION_DELIMITER } from './combineActions';
 
 export default function handleAction(type, reducers, defaultState) {
-  const typeValue = isSymbol(type)
-    ? type
-    : type.toString().split(ACTION_DELIMITER);
+  const typeValue = type.toString().split(ACTION_DELIMITER);
 
   const [nextReducer, throwReducer] = isFunction(reducers)
     ? [reducers, reducers]
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
-    const actionType = action.type;
-    if (isSymbol(typeValue)) {
-      if (actionType !== typeValue) {
-        return state;
-      }
-    } else if (!includes(typeValue, actionType)) {
+    if (!includes(typeValue, action.type.toString())) {
       return state;
     }
     return (action.error === true ? throwReducer : nextReducer)(state, action);

--- a/src/index.js
+++ b/src/index.js
@@ -9,5 +9,5 @@ export {
   createActions,
   handleAction,
   handleActions,
-  combineActions,
+  combineActions
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import createAction from './createAction';
 import handleAction from './handleAction';
 import handleActions from './handleActions';
+import combineActions from './combineActions'
 
 export {
   createAction,
   handleAction,
-  handleActions
+  handleActions,
+  combineActions,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 import createAction from './createAction';
 import handleAction from './handleAction';
 import handleActions from './handleActions';
-import combineActions from './combineActions'
+import combineActions from './combineActions';
 
 export {
   createAction,
   handleAction,
   handleActions,
-  combineActions,
+  combineActions
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,6 @@ export {
   createAction,
   createActions,
   handleAction,
+  handleActions,
   combineActions,
-  handleActions
 };


### PR DESCRIPTION
Close #31. Please see that issue for background and discussion.

### Changes

- adds `combineActions`, which takes a variadic list of action creators (functions), strings, or Symbols
- `handleAction`/`handleActions` can handle combined actions
- adds tests for the above

Note that there's a subtle change here that's backwards-compatible: 

> **Though Symbols are immutable, reducer checks against them are not done by reference, but by checking `toString` (as we do everything else).**

This won't break anyone, but it might surprise the few people that do use Symbol action types, [which is generally a bad idea](https://github.com/acdlite/redux-actions/issues/20#issuecomment-134340125).