### PR TITLE
Depend on specific lodash modules instead of all of lodash.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,15 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "lodash": "^4.13.1",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.identity": "^3.0.0",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isfunction": "^3.0.8",
+    "lodash.isnil": "^4.0.0",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.isstring": "^4.0.1",
+    "lodash.issymbol": "^4.0.1",
+    "lodash.reduce": "^4.6.0",
     "reduce-reducers": "^0.1.0"
   }
 }

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -1,4 +1,4 @@
-import identity from 'lodash/identity';
+import identity from 'lodash.identity';
 
 export default function createAction(type, payloadCreator, metaCreator) {
   const finalPayloadCreator = typeof payloadCreator === 'function'

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -1,10 +1,10 @@
-import identity from 'lodash/identity';
-import camelCase from 'lodash/camelCase';
-import isPlainObject from 'lodash/isPlainObject';
-import isArray from 'lodash/isArray';
-import reduce from 'lodash/reduce';
-import isString from 'lodash/isString';
-import isFunction from 'lodash/isFunction';
+import identity from 'lodash.identity';
+import camelCase from 'lodash.camelcase';
+import isPlainObject from 'lodash.isplainobject';
+import isArray from 'lodash.isarray';
+import reduce from 'lodash.reduce';
+import isString from 'lodash.isstring';
+import isFunction from 'lodash.isfunction';
 import createAction from './createAction';
 
 export default function createActions(actionsMap, ...identityActions) {

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,7 +1,7 @@
-import isFunction from 'lodash/isFunction';
-import identity from 'lodash/identity';
-import isNil from 'lodash/isNil';
-import isSymbol from 'lodash/isSymbol';
+import isFunction from 'lodash.isfunction';
+import identity from 'lodash.identity';
+import isNil from 'lodash.isnil';
+import isSymbol from 'lodash.issymbol';
 
 export default function handleAction(type, reducers, defaultState) {
   const typeValue = isSymbol(type)


### PR DESCRIPTION
Instead of depending on all of lodash, we can only depend on the specific functions that are used.