### PR TITLE
Make defaultState required when creating reducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ handleAction('FETCH_DATA', {
 
 If either `next()` or `throw()` are `undefined` or `null`, then the identity function is used for that reducer.
 
-The third parameter `defaultState` is required, and specifies a default or initial state, which is used when `undefined` is passed to the reducer.
+The third parameter `defaultState` is required, and is used when `undefined` is passed to the reducer.
 
 ### `handleActions(reducerMap, defaultState)`
 
@@ -162,7 +162,7 @@ import { handleActions } from 'redux-actions';
 
 Creates multiple reducers using `handleAction()` and combines them into a single reducer that handles multiple actions. Accepts a map where the keys are passed as the first parameter to `handleAction()` (the action type), and the values are passed as the second parameter (either a reducer or reducer map).
 
-The second parameter `defaultState` is required, and used when `undefined` is passed to the reducer.
+The second parameter `defaultState` is required, and is used when `undefined` is passed to the reducer.
 
 (Internally, `handleActions()` works by applying multiple reducers in sequence using [reduce-reducers](https://github.com/acdlite/reduce-reducers).)
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ expect(actionThree(3)).to.deep.equal({
 });
 ```
 
-### `handleAction(type, reducer | reducerMap, ?defaultState)`
+### `handleAction(type, reducer | reducerMap, defaultState)`
 
 ```js
 import { handleAction } from 'redux-actions';
@@ -147,14 +147,14 @@ Otherwise, you can specify separate reducers for `next()` and `throw()`. This AP
 handleAction('FETCH_DATA', {
   next(state, action) {...},
   throw(state, action) {...}
-});
+}, defaultState);
 ```
 
 If either `next()` or `throw()` are `undefined` or `null`, then the identity function is used for that reducer.
 
-The optional third parameter specifies a default or initial state, which is used when `undefined` is passed to the reducer.
+The third parameter `defaultState` is required, and specifies a default or initial state, which is used when `undefined` is passed to the reducer.
 
-### `handleActions(reducerMap, ?defaultState)`
+### `handleActions(reducerMap, defaultState)`
 
 ```js
 import { handleActions } from 'redux-actions';
@@ -162,7 +162,7 @@ import { handleActions } from 'redux-actions';
 
 Creates multiple reducers using `handleAction()` and combines them into a single reducer that handles multiple actions. Accepts a map where the keys are passed as the first parameter to `handleAction()` (the action type), and the values are passed as the second parameter (either a reducer or reducer map).
 
-The optional second parameter specifies a default or initial state, which is used when `undefined` is passed to the reducer.
+The second parameter `defaultState` is required, and used when `undefined` is passed to the reducer.
 
 (Internally, `handleActions()` works by applying multiple reducers in sequence using [reduce-reducers](https://github.com/acdlite/reduce-reducers).)
 

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -11,7 +11,10 @@ describe('handleAction()', () => {
     it('should throw an error if defaultState is not specified', () => {
       expect(() => {
         handleAction(type, undefined);
-      }).to.throw(Error, 'Expected defaultState for reducer handling TYPE to be defined');
+      }).to.throw(
+        Error,
+        'defaultState for reducer handling TYPE should be defined'
+      );
     });
 
     describe('resulting reducer', () => {
@@ -80,7 +83,11 @@ describe('handleAction()', () => {
     it('should throw an error if defaultState is not specified', () => {
       expect(() => {
         handleAction(type, { next: () => null });
-      }).to.throw(Error, 'Expected defaultState for reducer handling TYPE to be defined');
+      })
+      .to.throw(
+        Error,
+        'defaultState for reducer handling TYPE should be defined'
+      );
     });
 
     describe('resulting reducer', () => {
@@ -215,7 +222,7 @@ describe('handleAction()', () => {
 
   describe('with invalid actions', () => {
     it('should throw a descriptive error when the action object is missing', () => {
-      const reducer = handleAction(createAction('ACTION_1'), identity);
+      const reducer = handleAction(createAction('ACTION_1'), identity, {});
       expect(
         () => reducer(undefined)
       ).to.throw(
@@ -225,7 +232,7 @@ describe('handleAction()', () => {
     });
 
     it('should throw a descriptive error when the action type is missing', () => {
-      const reducer = handleAction(createAction('ACTION_1'), identity);
+      const reducer = handleAction(createAction('ACTION_1'), identity, {});
       expect(
         () => reducer(undefined, {})
       ).to.throw(
@@ -235,7 +242,7 @@ describe('handleAction()', () => {
     });
 
     it('should throw a descriptive error when the action type is not a string or symbol', () => {
-      const reducer = handleAction(createAction('ACTION_1'), identity);
+      const reducer = handleAction(createAction('ACTION_1'), identity, {});
       expect(
         () => reducer(undefined, { type: false })
       ).to.throw(

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -52,11 +52,11 @@ describe('handleAction()', () => {
       it('accepts a default state used when the previous state is undefined', () => {
         const reducer = handleAction(type, (state, action) => ({
           counter: state.counter + action.payload
-        }), { counter: 5 });
+        }), { counter: 3 });
 
         expect(reducer(undefined, { type, payload: 7 }))
           .to.deep.equal({
-            counter: 12
+            counter: 10
           });
       });
 

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -3,18 +3,25 @@ import { handleAction, createAction, createActions, combineActions } from '../';
 
 describe('handleAction()', () => {
   const type = 'TYPE';
-  const prevState = { counter: 3 };
+  const defaultState = { counter: 0 };
+  const previousState = { counter: 3 };
 
   describe('single handler form', () => {
+    it('should throw an error if defaultState is not specified', () => {
+      expect(() => {
+        handleAction(type, undefined)
+      }).to.throw(Error, 'Expected defaultState for reducer handling TYPE to be defined')
+    });
+
     describe('resulting reducer', () => {
       it('returns previous state if type does not match', () => {
-        const reducer = handleAction('NOTTYPE', () => null);
-        expect(reducer(prevState, { type })).to.equal(prevState);
+        const reducer = handleAction('NOTTYPE', () => null, defaultState);
+        expect(reducer(previousState, { type })).to.equal(previousState);
       });
 
       it('returns default state if type does not match', () => {
         const reducer = handleAction('NOTTYPE', () => null, { counter: 7 });
-        expect(reducer(undefined, { type }))
+        expect(reducer(undefined, { type }, defaultState))
           .to.deep.equal({
             counter: 7
           });
@@ -23,8 +30,8 @@ describe('handleAction()', () => {
       it('accepts single function as handler', () => {
         const reducer = handleAction(type, (state, action) => ({
           counter: state.counter + action.payload
-        }));
-        expect(reducer(prevState, { type, payload: 7 }))
+        }), defaultState);
+        expect(reducer(previousState, { type, payload: 7 }))
           .to.deep.equal({
             counter: 10
           });
@@ -34,22 +41,22 @@ describe('handleAction()', () => {
         const incrementAction = createAction(type);
         const reducer = handleAction(incrementAction, (state, action) => ({
           counter: state.counter + action.payload
-        }));
+        }), defaultState);
 
-        expect(reducer(prevState, incrementAction(7)))
+        expect(reducer(previousState, incrementAction(7)))
           .to.deep.equal({
             counter: 10
           });
       });
 
-      it('accepts single function as handler and a default state', () => {
+      it('accepts a default state used when the previous state is undefined', () => {
         const reducer = handleAction(type, (state, action) => ({
           counter: state.counter + action.payload
-        }), { counter: 3 });
+        }), { counter: 5 });
 
         expect(reducer(undefined, { type, payload: 7 }))
           .to.deep.equal({
-            counter: 10
+            counter: 12
           });
       });
 
@@ -58,21 +65,27 @@ describe('handleAction()', () => {
 
         const reducer = handleAction(increment, (state, { payload }) => ({
           counter: state.counter + payload
-        }), { counter: 3 });
+        }), defaultState);
 
         expect(reducer(undefined, increment(7)))
           .to.deep.equal({
-            counter: 10
+            counter: 7
           });
       });
     });
   });
 
   describe('map of handlers form', () => {
+    it('should throw an error if defaultState is not specified', () => {
+      expect(() => {
+        handleAction(type, { next: () => null })
+      }).to.throw(Error, 'Expected defaultState for reducer handling TYPE to be defined')
+    });
+
     describe('resulting reducer', () => {
       it('returns previous state if type does not match', () => {
-        const reducer = handleAction('NOTTYPE', { next: () => null });
-        expect(reducer(prevState, { type })).to.equal(prevState);
+        const reducer = handleAction('NOTTYPE', { next: () => null }, defaultState);
+        expect(reducer(previousState, { type })).to.equal(previousState);
       });
 
       it('uses `next()` if action does not represent an error', () => {
@@ -80,8 +93,8 @@ describe('handleAction()', () => {
           next: (state, action) => ({
             counter: state.counter + action.payload
           })
-        });
-        expect(reducer(prevState, { type, payload: 7 }))
+        }, defaultState);
+        expect(reducer(previousState, { type, payload: 7 }))
           .to.deep.equal({
             counter: 10
           });
@@ -92,19 +105,19 @@ describe('handleAction()', () => {
           throw: (state, action) => ({
             counter: state.counter + action.payload
           })
-        });
+        }, defaultState);
 
-        expect(reducer(prevState, { type, payload: 7, error: true }))
+        expect(reducer(previousState, { type, payload: 7, error: true }))
           .to.deep.equal({
             counter: 10
           });
       });
 
       it('returns previous state if matching handler is not function', () => {
-        const reducer = handleAction(type, { next: null, error: 123 });
-        expect(reducer(prevState, { type, payload: 123 })).to.equal(prevState);
-        expect(reducer(prevState, { type, payload: 123, error: true }))
-          .to.equal(prevState);
+        const reducer = handleAction(type, { next: null, error: 123 }, defaultState);
+        expect(reducer(previousState, { type, payload: 123 })).to.equal(previousState);
+        expect(reducer(previousState, { type, payload: 123, error: true }))
+          .to.equal(previousState);
       });
     });
   });
@@ -114,7 +127,8 @@ describe('handleAction()', () => {
       const action1 = createAction('ACTION_1');
       const reducer = handleAction(
         combineActions(action1, 'ACTION_2', 'ACTION_3'),
-        (state, { payload }) => ({ ...state, number: state.number + payload })
+        (state, { payload }) => ({ ...state, number: state.number + payload }),
+        defaultState
       );
 
       expect(reducer({ number: 1 }, action1(1))).to.deep.equal({ number: 2 });
@@ -128,7 +142,7 @@ describe('handleAction()', () => {
         next(state, { payload }) {
           return { ...state, number: state.number + payload };
         }
-      });
+      }, defaultState);
 
       expect(reducer({ number: 1 }, action1(1))).to.deep.equal({ number: 2 });
       expect(reducer({ number: 1 }, { type: 'ACTION_2', payload: 2 })).to.deep.equal({ number: 3 });
@@ -145,7 +159,7 @@ describe('handleAction()', () => {
         throw(state) {
           return { ...state, threw: true };
         }
-      });
+      }, defaultState);
       const error = new Error;
 
       expect(reducer({ number: 0 }, action1(error)))
@@ -160,6 +174,7 @@ describe('handleAction()', () => {
       const reducer = handleAction(
         combineActions('ACTION_1', 'ACTION_2'),
         (state, { payload }) => ({ ...state, state: state.number + payload }),
+        defaultState
       );
 
       const state = { number: 0 };
@@ -171,11 +186,11 @@ describe('handleAction()', () => {
       const reducer = handleAction(
         combineActions('INCREMENT', 'DECREMENT'),
         (state, { payload }) => ({ ...state, counter: state.counter + payload }),
-        { counter: 10 }
+        defaultState
       );
 
-      expect(reducer(undefined, { type: 'INCREMENT', payload: +1 })).to.deep.equal({ counter: 11 });
-      expect(reducer(undefined, { type: 'DECREMENT', payload: -1 })).to.deep.equal({ counter: 9 });
+      expect(reducer(undefined, { type: 'INCREMENT', payload: +1 })).to.deep.equal({ counter: +1 });
+      expect(reducer(undefined, { type: 'DECREMENT', payload: -1 })).to.deep.equal({ counter: -1 });
     });
 
     it('should handle combined actions with symbols', () => {
@@ -184,7 +199,8 @@ describe('handleAction()', () => {
       const action3 = createAction(Symbol('ACTION_3'));
       const reducer = handleAction(
         combineActions(action1, action2, action3),
-        (state, { payload }) => ({ ...state, number: state.number + payload })
+        (state, { payload }) => ({ ...state, number: state.number + payload }),
+        defaultState
       );
 
       expect(reducer({ number: 0 }, action1(1)))

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -3,8 +3,8 @@ import { handleAction, createAction, createActions, combineActions } from '../';
 
 describe('handleAction()', () => {
   const type = 'TYPE';
+  const prevState = { counter: 3 };
   const defaultState = { counter: 0 };
-  const previousState = { counter: 3 };
 
   describe('single handler form', () => {
     it('should throw an error if defaultState is not specified', () => {
@@ -16,12 +16,12 @@ describe('handleAction()', () => {
     describe('resulting reducer', () => {
       it('returns previous state if type does not match', () => {
         const reducer = handleAction('NOTTYPE', () => null, defaultState);
-        expect(reducer(previousState, { type })).to.equal(previousState);
+        expect(reducer(prevState, { type })).to.equal(prevState);
       });
 
       it('returns default state if type does not match', () => {
         const reducer = handleAction('NOTTYPE', () => null, { counter: 7 });
-        expect(reducer(undefined, { type }, defaultState))
+        expect(reducer(undefined, { type }))
           .to.deep.equal({
             counter: 7
           });
@@ -31,7 +31,7 @@ describe('handleAction()', () => {
         const reducer = handleAction(type, (state, action) => ({
           counter: state.counter + action.payload
         }), defaultState);
-        expect(reducer(previousState, { type, payload: 7 }))
+        expect(reducer(prevState, { type, payload: 7 }))
           .to.deep.equal({
             counter: 10
           });
@@ -43,7 +43,7 @@ describe('handleAction()', () => {
           counter: state.counter + action.payload
         }), defaultState);
 
-        expect(reducer(previousState, incrementAction(7)))
+        expect(reducer(prevState, incrementAction(7)))
           .to.deep.equal({
             counter: 10
           });
@@ -85,7 +85,7 @@ describe('handleAction()', () => {
     describe('resulting reducer', () => {
       it('returns previous state if type does not match', () => {
         const reducer = handleAction('NOTTYPE', { next: () => null }, defaultState);
-        expect(reducer(previousState, { type })).to.equal(previousState);
+        expect(reducer(prevState, { type })).to.equal(prevState);
       });
 
       it('uses `next()` if action does not represent an error', () => {
@@ -94,7 +94,7 @@ describe('handleAction()', () => {
             counter: state.counter + action.payload
           })
         }, defaultState);
-        expect(reducer(previousState, { type, payload: 7 }))
+        expect(reducer(prevState, { type, payload: 7 }))
           .to.deep.equal({
             counter: 10
           });
@@ -107,7 +107,7 @@ describe('handleAction()', () => {
           })
         }, defaultState);
 
-        expect(reducer(previousState, { type, payload: 7, error: true }))
+        expect(reducer(prevState, { type, payload: 7, error: true }))
           .to.deep.equal({
             counter: 10
           });
@@ -115,9 +115,9 @@ describe('handleAction()', () => {
 
       it('returns previous state if matching handler is not function', () => {
         const reducer = handleAction(type, { next: null, error: 123 }, defaultState);
-        expect(reducer(previousState, { type, payload: 123 })).to.equal(previousState);
-        expect(reducer(previousState, { type, payload: 123, error: true }))
-          .to.equal(previousState);
+        expect(reducer(prevState, { type, payload: 123 })).to.equal(prevState);
+        expect(reducer(prevState, { type, payload: 123, error: true }))
+          .to.equal(prevState);
       });
     });
   });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -9,8 +9,8 @@ describe('handleAction()', () => {
   describe('single handler form', () => {
     it('should throw an error if defaultState is not specified', () => {
       expect(() => {
-        handleAction(type, undefined)
-      }).to.throw(Error, 'Expected defaultState for reducer handling TYPE to be defined')
+        handleAction(type, undefined);
+      }).to.throw(Error, 'Expected defaultState for reducer handling TYPE to be defined');
     });
 
     describe('resulting reducer', () => {
@@ -78,8 +78,8 @@ describe('handleAction()', () => {
   describe('map of handlers form', () => {
     it('should throw an error if defaultState is not specified', () => {
       expect(() => {
-        handleAction(type, { next: () => null })
-      }).to.throw(Error, 'Expected defaultState for reducer handling TYPE to be defined')
+        handleAction(type, { next: () => null });
+      }).to.throw(Error, 'Expected defaultState for reducer handling TYPE to be defined');
     });
 
     describe('resulting reducer', () => {

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -2,22 +2,25 @@ import { expect } from 'chai';
 import { handleActions, createAction, createActions, combineActions } from '../';
 
 describe('handleActions', () => {
-  const defaultState = { counter: 0 }
-  
+  const defaultState = { counter: 0 };
+
   it('should throw an error when defaultState is not specified', () => {
     expect(() => {
       handleActions({
         INCREMENT: ({ counter }, { payload: amount }) => ({
           counter: counter + amount
         }),
-    
+
         DECREMENT: ({ counter }, { payload: amount }) => ({
           counter: counter - amount
         })
       });
-    }).to.throw(Error, 'Expected defaultState for reducer handling INCREMENT, DECREMENT to be defined')
-  })
-  
+    }).to.throw(
+      Error,
+      'Expected defaultState for reducer handling INCREMENT, DECREMENT to be defined'
+    );
+  });
+
   it('create a single handler from a map of multiple action handlers', () => {
     const reducer = handleActions({
       INCREMENT: ({ counter }, { payload: amount }) => ({
@@ -46,7 +49,7 @@ describe('handleActions', () => {
       [INCREMENT]: ({ counter }, { payload: amount }) => ({
         counter: counter + amount
       })
-    });
+    }, defaultState);
 
     expect(reducer({ counter: 3 }, { type: INCREMENT, payload: 7 }))
       .to.deep.equal({
@@ -54,7 +57,7 @@ describe('handleActions', () => {
       });
   });
 
-  it('accepts a default state as the second parameter', () => {
+  it('accepts a default state used when previous state is undefined', () => {
     const reducer = handleActions({
       INCREMENT: ({ counter }, { payload: amount }) => ({
         counter: counter + amount
@@ -77,7 +80,7 @@ describe('handleActions', () => {
       [incrementAction]: ({ counter }, { payload: amount }) => ({
         counter: counter + amount
       })
-    });
+    }, defaultState);
 
     expect(reducer({ counter: 3 }, incrementAction(7)))
       .to.deep.equal({
@@ -97,12 +100,12 @@ describe('handleActions', () => {
       [combineActions(increment, decrement)](state, { payload: { amount } }) {
         return { ...state, counter: state.counter + amount };
       }
-    }, initialState);
+    }, defaultState);
 
     expect(reducer(initialState, increment(5))).to.deep.equal({ counter: 15 });
     expect(reducer(initialState, decrement(5))).to.deep.equal({ counter: 5 });
     expect(reducer(initialState, { type: 'NOT_TYPE', payload: 1000 })).to.equal(initialState);
-    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 15 });
+    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 5 });
   });
 
   it('should accept combined actions as action types in the next/throw form', () => {
@@ -123,14 +126,14 @@ describe('handleActions', () => {
           return { ...state, counter: 0 };
         }
       }
-    }, initialState);
+    }, defaultState);
     const error = new Error;
 
     // non-errors
     expect(reducer(initialState, increment(5))).to.deep.equal({ counter: 15 });
     expect(reducer(initialState, decrement(5))).to.deep.equal({ counter: 5 });
     expect(reducer(initialState, { type: 'NOT_TYPE', payload: 1000 })).to.equal(initialState);
-    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 15 });
+    expect(reducer(undefined, increment(5))).to.deep.equal({ counter: 5 });
 
     // errors
     expect(
@@ -152,7 +155,7 @@ describe('handleActions', () => {
       [decrement]: ({ counter }, { payload }) => ({
         counter: counter - payload
       })
-    });
+    }, defaultState);
 
     expect(reducer({ counter: 3 }, increment(2)))
       .to.deep.equal({

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -4,7 +4,7 @@ import { handleActions, createAction, createActions, combineActions } from '../'
 describe('handleActions', () => {
   const defaultState = { counter: 0 };
 
-  it('should throw an error when defaultState is not specified', () => {
+  it('should throw an error when defaultState is not defined', () => {
     expect(() => {
       handleActions({
         INCREMENT: ({ counter }, { payload: amount }) => ({
@@ -17,7 +17,25 @@ describe('handleActions', () => {
       });
     }).to.throw(
       Error,
-      'Expected defaultState for reducer handling INCREMENT, DECREMENT to be defined'
+      'defaultState for reducer handling INCREMENT should be defined'
+    );
+  });
+
+  it('should throw an error when defaultState is not defined for combinedActions', () => {
+    expect(() => {
+      handleActions({
+        [
+          combineActions(
+            'INCREMENT',
+            'DECREMENT'
+          )
+        ]: ({ counter }, { type, payload: amount }) => ({
+          counter: counter + (type === 'INCREMENT' ? +1 : -1) * amount
+        })
+      });
+    }).to.throw(
+      Error,
+      'defaultState for reducer handling INCREMENT, DECREMENT should be defined'
     );
   });
 

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -2,6 +2,22 @@ import { expect } from 'chai';
 import { handleActions, createAction, createActions, combineActions } from '../';
 
 describe('handleActions', () => {
+  const defaultState = { counter: 0 }
+  
+  it('should throw an error when defaultState is not specified', () => {
+    expect(() => {
+      handleActions({
+        INCREMENT: ({ counter }, { payload: amount }) => ({
+          counter: counter + amount
+        }),
+    
+        DECREMENT: ({ counter }, { payload: amount }) => ({
+          counter: counter - amount
+        })
+      });
+    }).to.throw(Error, 'Expected defaultState for reducer handling INCREMENT, DECREMENT to be defined')
+  })
+  
   it('create a single handler from a map of multiple action handlers', () => {
     const reducer = handleActions({
       INCREMENT: ({ counter }, { payload: amount }) => ({
@@ -11,7 +27,7 @@ describe('handleActions', () => {
       DECREMENT: ({ counter }, { payload: amount }) => ({
         counter: counter - amount
       })
-    });
+    }, defaultState);
 
     expect(reducer({ counter: 3 }, { type: 'INCREMENT', payload: 7 }))
       .to.deep.equal({

--- a/src/assertDefaultState.js
+++ b/src/assertDefaultState.js
@@ -1,0 +1,7 @@
+import isUndefined from 'lodash/isUndefined';
+
+export default function assertDefaultState(defaultState, actionTypes) {
+  if (isUndefined(defaultState)) {
+    throw new Error(`Expected defaultState for reducer handling ${actionTypes.join(', ')} to be defined`)
+  }
+}

--- a/src/assertDefaultState.js
+++ b/src/assertDefaultState.js
@@ -2,6 +2,8 @@ import isUndefined from 'lodash/isUndefined';
 
 export default function assertDefaultState(defaultState, actionTypes) {
   if (isUndefined(defaultState)) {
-    throw new Error(`Expected defaultState for reducer handling ${actionTypes.join(', ')} to be defined`)
+    throw new Error(
+      `Expected defaultState for reducer handling ${actionTypes.join(', ')} to be defined`
+    );
   }
 }

--- a/src/assertDefaultState.js
+++ b/src/assertDefaultState.js
@@ -1,9 +1,0 @@
-import isUndefined from 'lodash/isUndefined';
-
-export default function assertDefaultState(defaultState, actionTypes) {
-  if (isUndefined(defaultState)) {
-    throw new Error(
-      `Expected defaultState for reducer handling ${actionTypes.join(', ')} to be defined`
-    );
-  }
-}

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,17 +1,14 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
-import isUndefined from 'lodash/isUndefined';
+import assertDefaultState from './assertDefaultState';
 import includes from 'lodash/includes';
 import { ACTION_TYPE_DELIMITER } from './combineActions';
 
 export default function handleAction(actionType, reducers, defaultState) {
   const actionTypes = actionType.toString().split(ACTION_TYPE_DELIMITER);
+  assertDefaultState(defaultState, actionTypes);
 
-  if (isUndefined(defaultState)) {
-    throw new Error(`Expected defaultState for reducer handling ${actionTypes} to be defined`)
-  }
-  
   const [nextReducer, throwReducer] = isFunction(reducers)
     ? [reducers, reducers]
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,12 +1,17 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
+import isUndefined from 'lodash/isUndefined';
 import includes from 'lodash/includes';
 import { ACTION_TYPE_DELIMITER } from './combineActions';
 
 export default function handleAction(actionType, reducers, defaultState) {
   const actionTypes = actionType.toString().split(ACTION_TYPE_DELIMITER);
 
+  if (isUndefined(defaultState)) {
+    throw new Error(`Expected defaultState for reducer handling ${actionTypes} to be defined`)
+  }
+  
   const [nextReducer, throwReducer] = isFunction(reducers)
     ? [reducers, reducers]
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,7 +1,7 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
-import assertDefaultState from './assertDefaultState';
+import isUndefined from 'lodash/isUndefined';
 import includes from 'lodash/includes';
 import invariant from 'invariant';
 import { isFSA } from 'flux-standard-action';
@@ -9,7 +9,10 @@ import { ACTION_TYPE_DELIMITER } from './combineActions';
 
 export default function handleAction(actionType, reducers, defaultState) {
   const actionTypes = actionType.toString().split(ACTION_TYPE_DELIMITER);
-  assertDefaultState(defaultState, actionTypes);
+  invariant(
+    !isUndefined(defaultState),
+    `defaultState for reducer handling ${actionTypes.join(', ')} should be defined`
+  );
 
   const [nextReducer, throwReducer] = isFunction(reducers)
     ? [reducers, reducers]

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -1,9 +1,13 @@
 import handleAction from './handleAction';
 import ownKeys from './ownKeys';
+import assertDefaultState from './assertDefaultState';
 import reduceReducers from 'reduce-reducers';
 
 export default function handleActions(handlers, defaultState) {
-  const reducers = ownKeys(handlers).map(type => handleAction(type, handlers[type]));
+  const actionTypes = ownKeys(handlers);
+  assertDefaultState(defaultState, actionTypes);
+
+  const reducers = actionTypes.map(type => handleAction(type, handlers[type]));
   const reducer = reduceReducers(...reducers);
 
   return (state = defaultState, action) => reducer(state, action);

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -1,14 +1,15 @@
 import handleAction from './handleAction';
 import ownKeys from './ownKeys';
-import assertDefaultState from './assertDefaultState';
 import reduceReducers from 'reduce-reducers';
 
 export default function handleActions(handlers, defaultState) {
-  const actionTypes = ownKeys(handlers);
-  assertDefaultState(defaultState, actionTypes);
-
-  const reducers = actionTypes.map(type => handleAction(type, handlers[type], defaultState));
+  const reducers = ownKeys(handlers).map(type =>
+    handleAction(
+      type,
+      handlers[type],
+      defaultState
+    )
+  );
   const reducer = reduceReducers(...reducers);
-
   return (state, action) => reducer(state, action);
 }

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -7,8 +7,8 @@ export default function handleActions(handlers, defaultState) {
   const actionTypes = ownKeys(handlers);
   assertDefaultState(defaultState, actionTypes);
 
-  const reducers = actionTypes.map(type => handleAction(type, handlers[type]));
+  const reducers = actionTypes.map(type => handleAction(type, handlers[type], defaultState));
   const reducer = reduceReducers(...reducers);
 
-  return (state = defaultState, action) => reducer(state, action);
+  return (state, action) => reducer(state, action);
 }


### PR DESCRIPTION
Close #18.

See that issue and also https://github.com/reactjs/redux/issues/514 for background and discussion. 
***
**TL;DR**

We can prevent downstream reducer sanity errors [like this one](https://github.com/reactjs/redux/blob/master/src/combineReducers.js#L63) by throwing earlier.
