### PR TITLE
Check type of payload creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ If you don’t use [npm](https://www.npmjs.com), you may grab the latest [UMD](h
 import { createAction } from 'redux-actions';
 ```
 
-Wraps an action creator so that its return value is the payload of a Flux Standard Action. If no payload creator is passed, or if it's not a function, the identity function is used.
+Wraps an action creator so that its return value is the payload of a Flux Standard Action. 
+
+`payloadCreator` must be a function or `undefined`. If `payloadCreator` is `undefined`, the identity function is used.
 
 Example:
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
+    "invariant": "^2.2.1",
     "lodash": "^4.13.1",
     "reduce-reducers": "^0.1.0"
   }

--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -30,7 +30,7 @@ describe('createAction()', () => {
         expect(() => {
           createAction(type, badPayloadCreator);
         })
-        .to.throw(TypeError, 'Expected payloadCreator to be a function or undefined');
+        .to.throw(Error, 'Expected payloadCreator to be a function or undefined');
       });
     });
 

--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -24,13 +24,16 @@ describe('createAction()', () => {
     });
 
     it('should throw an error if payloadCreator is not a function or undefined', () => {
-      const badPayloadCreators = [1, false, null, 'string', {}, []];
+      const wrongTypePayloadCreators = [1, false, null, 'string', {}, []];
 
-      badPayloadCreators.forEach(badPayloadCreator => {
+      wrongTypePayloadCreators.forEach(wrongTypePayloadCreator => {
         expect(() => {
-          createAction(type, badPayloadCreator);
+          createAction(type, wrongTypePayloadCreator);
         })
-        .to.throw(Error, 'Expected payloadCreator to be a function or undefined');
+        .to.throw(
+          Error,
+          'Expected payloadCreator to be a function or undefined'
+        );
       });
     });
 

--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -23,7 +23,18 @@ describe('createAction()', () => {
       });
     });
 
-    it('uses identity function if payloadCreator is not a function', () => {
+    it('should throw an error if payloadCreator is not a function or undefined', () => {
+      const badPayloadCreators = [1, false, null, 'string', {}, []];
+
+      badPayloadCreators.forEach(badPayloadCreator => {
+        expect(() => {
+          createAction(type, badPayloadCreator);
+        })
+        .to.throw(TypeError, 'Expected payloadCreator to be a function or undefined');
+      });
+    });
+
+    it('uses identity function if payloadCreator is undefined', () => {
       const actionCreator = createAction(type);
       const foobar = { foo: 'bar' };
       const action = actionCreator(foobar);
@@ -35,7 +46,7 @@ describe('createAction()', () => {
     });
 
     it('accepts a second parameter for adding meta to object', () => {
-      const actionCreator = createAction(type, null, ({ cid }) => ({ cid }));
+      const actionCreator = createAction(type, undefined, ({ cid }) => ({ cid }));
       const foobar = { foo: 'bar', cid: 5 };
       const action = actionCreator(foobar);
       expect(action).to.deep.equal({
@@ -70,7 +81,7 @@ describe('createAction()', () => {
     });
 
     it('sets error to true if payload is an Error object and meta is provided', () => {
-      const actionCreator = createAction(type, null, (_, meta) => meta);
+      const actionCreator = createAction(type, undefined, (_, meta) => meta);
       const errObj = new TypeError('this is an error');
 
       const errAction = actionCreator(errObj, { foo: 'bar' });
@@ -93,13 +104,13 @@ describe('createAction()', () => {
         type
       });
 
-      const explictNullAction = createAction(type)(null);
+      const explictNullAction = createAction(type)(undefined);
       expect(explictNullAction).to.deep.equal({
         type
       });
 
       const baz = '1';
-      const actionCreator = createAction(type, null, () => ({ bar: baz }));
+      const actionCreator = createAction(type, undefined, () => ({ bar: baz }));
       expect(actionCreator()).to.deep.equal({
         type,
         meta: {

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -1,9 +1,10 @@
 import identity from 'lodash/identity';
+import isFunction from 'lodash/isFunction';
 
-export default function createAction(type, payloadCreator, metaCreator) {
-  const finalPayloadCreator = typeof payloadCreator === 'function'
-    ? payloadCreator
-    : identity;
+export default function createAction(type, payloadCreator = identity, metaCreator) {
+  if (!isFunction(payloadCreator)) {
+    throw new TypeError('Expected payloadCreator to be a function or undefined');
+  }
 
   const actionHandler = (...args) => {
     const hasError = args[0] instanceof Error;
@@ -12,7 +13,7 @@ export default function createAction(type, payloadCreator, metaCreator) {
       type
     };
 
-    const payload = hasError ? args[0] : finalPayloadCreator(...args);
+    const payload = hasError ? args[0] : payloadCreator(...args);
     if (!(payload === null || payload === undefined)) {
       action.payload = payload;
     }
@@ -22,7 +23,7 @@ export default function createAction(type, payloadCreator, metaCreator) {
       action.error = true;
     }
 
-    if (typeof metaCreator === 'function') {
+    if (isFunction(metaCreator)) {
       action.meta = metaCreator(...args);
     }
 

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -1,10 +1,9 @@
 import identity from 'lodash/identity';
 import isFunction from 'lodash/isFunction';
+import invariant from 'invariant';
 
 export default function createAction(type, payloadCreator = identity, metaCreator) {
-  if (!isFunction(payloadCreator)) {
-    throw new TypeError('Expected payloadCreator to be a function or undefined');
-  }
+  invariant(isFunction(payloadCreator), 'Expected payloadCreator to be a function or undefined');
 
   const actionCreator = (...args) => {
     const hasError = args[0] instanceof Error;

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -4,7 +4,10 @@ import isUndefined from 'lodash/isUndefined';
 import invariant from 'invariant';
 
 export default function createAction(type, payloadCreator = identity, metaCreator) {
-  invariant(isFunction(payloadCreator), 'Expected payloadCreator to be a function or undefined');
+  invariant(
+    isFunction(payloadCreator),
+    'Expected payloadCreator to be a function or undefined'
+  );
 
   const actionCreator = (...args) => {
     const hasError = args[0] instanceof Error;
@@ -13,7 +16,7 @@ export default function createAction(type, payloadCreator = identity, metaCreato
       type
     };
 
-    const payload = hasError ? args[0] : finalPayloadCreator(...args);
+    const payload = hasError ? args[0] : payloadCreator(...args);
     if (!isUndefined(payload)) {
       action.payload = payload;
     }


### PR DESCRIPTION
This takes care of the first example in the `createAction` spec outlined [here](https://github.com/acdlite/redux-actions/pull/128#issuecomment-244896176).

This contains breaking changes, so it might be worth including in https://github.com/acdlite/redux-actions/issues/122.
