### PR TITLE
Prefer "actionCreator" to "actionHandler" name

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -5,7 +5,7 @@ export default function createAction(type, payloadCreator, metaCreator) {
     ? payloadCreator
     : identity;
 
-  const actionHandler = (...args) => {
+  const actionCreator = (...args) => {
     const hasError = args[0] instanceof Error;
 
     const action = {
@@ -29,7 +29,7 @@ export default function createAction(type, payloadCreator, metaCreator) {
     return action;
   };
 
-  actionHandler.toString = () => type.toString();
+  actionCreator.toString = () => type.toString();
 
-  return actionHandler;
+  return actionCreator;
 }


### PR DESCRIPTION
By rights, `actionHandler` should be called `actionCreator`. 

This name is standard in the [Redux documentation](http://redux.js.org/docs/basics/Actions.html#action-creators) and community.

Also, "handler" in `actionHandler` collides with "handle" in `handleAction`, which is an avoidable point of confusion.