### PR TITLE
handleAction should accept an empty action i.e., {}

### DIFF
--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -19,6 +19,13 @@ describe('handleAction()', () => {
             counter: 7
           });
       });
+      it('returns default state if action is empty', () => {
+        const reducer = handleAction('NOTTYPE', () => null, { counter: 7 });
+        expect(reducer(undefined, {}))
+          .to.deep.equal({
+            counter: 7
+          });
+      });
 
       it('accepts single function as handler', () => {
         const reducer = handleAction(type, (state, action) => ({

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -12,7 +12,7 @@ export default function handleAction(actionType, reducers, defaultState) {
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
-    if (!includes(actionTypes, action.type.toString())) {
+    if (action.type == null || !includes(actionTypes, action.type.toString())) {
       return state;
     }
 


### PR DESCRIPTION
I write a lot of tests like the following which work until recent changes:
```javascript
describe('should have this initial state', () => {
  it('should start with no crumbs', () => {
    const next_state = reducer(undefined, {})
    expect(selectors.crumbs(next_state)).to.have.length(0)
  })
})

````