### PR TITLE
fix(handleAction): Add descriptive error for missing or invalid actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
+    "invariant": "^2.2.1",
     "lodash": "^4.13.1",
     "reduce-reducers": "^0.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "eslint-config-airbnb-base": "^1.0.3",
     "eslint-plugin-import": "^1.5.0",
     "eslint-watch": "^2.1.13",
-    "flux-standard-action": "^0.6.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.5.3",
     "webpack": "^1.13.1"
   },
   "dependencies": {
+    "flux-standard-action": "^1.0.0",
     "invariant": "^2.2.1",
     "lodash": "^4.13.1",
     "reduce-reducers": "^0.1.0"

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -204,6 +204,7 @@ describe('handleAction()', () => {
         (state) => state
       );
       expect(() => reducer(undefined))
+      // eslint-disable-next-line max-len
         .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
     });
 
@@ -214,6 +215,7 @@ describe('handleAction()', () => {
         (state) => state
       );
       expect(() => reducer(undefined, {}))
+      // eslint-disable-next-line max-len
         .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
     });
 
@@ -224,6 +226,7 @@ describe('handleAction()', () => {
         (state) => state
       );
       expect(() => reducer(undefined, { type: false }))
+      // eslint-disable-next-line max-len
         .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
     });
   });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -200,23 +200,32 @@ describe('handleAction()', () => {
   describe('with invalid actions', () => {
     it('should throw a descriptive error when the action object is missing', () => {
       const reducer = handleAction(createAction('ACTION_1'), identity);
-      expect(() => reducer(undefined))
-      // eslint-disable-next-line max-len
-        .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
+      expect(
+        () => reducer(undefined)
+      ).to.throw(
+        Error,
+        'The FSA spec mandates an action object with a type. Try using the createAction(s) method.'
+      );
     });
 
     it('should throw a descriptive error when the action type is missing', () => {
       const reducer = handleAction(createAction('ACTION_1'), identity);
-      expect(() => reducer(undefined, {}))
-      // eslint-disable-next-line max-len
-        .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
+      expect(
+        () => reducer(undefined, {})
+      ).to.throw(
+        Error,
+        'The FSA spec mandates an action object with a type. Try using the createAction(s) method.'
+      );
     });
 
     it('should throw a descriptive error when the action type is not a string or symbol', () => {
       const reducer = handleAction(createAction('ACTION_1'), identity);
-      expect(() => reducer(undefined, { type: false }))
-      // eslint-disable-next-line max-len
-        .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
+      expect(
+        () => reducer(undefined, { type: false })
+      ).to.throw(
+        Error,
+        'The FSA spec mandates an action object with a type. Try using the createAction(s) method.'
+      );
     });
   });
 });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -195,4 +195,36 @@ describe('handleAction()', () => {
         .to.deep.equal({ number: 3 });
     });
   });
+
+  describe('with invalid actions', () => {
+    it('should throw a descriptive error when the action object is missing', () => {
+      const action1 = createAction('ACTION_1');
+      const reducer = handleAction(
+        action1,
+        (state) => state
+      );
+      expect(() => reducer(undefined))
+        .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
+    });
+
+    it('should throw a descriptive error when the action type is missing', () => {
+      const action1 = createAction('ACTION_1');
+      const reducer = handleAction(
+        action1,
+        (state) => state
+      );
+      expect(() => reducer(undefined, {}))
+        .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
+    });
+
+    it('should throw a descriptive error when the action type is not a string or symbol', () => {
+      const action1 = createAction('ACTION_1');
+      const reducer = handleAction(
+        action1,
+        (state) => state
+      );
+      expect(() => reducer(undefined, { type: false }))
+        .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
+    });
+  });
 });

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import identity from 'lodash/identity';
 import { handleAction, createAction, createActions, combineActions } from '../';
 
 describe('handleAction()', () => {
@@ -198,33 +199,21 @@ describe('handleAction()', () => {
 
   describe('with invalid actions', () => {
     it('should throw a descriptive error when the action object is missing', () => {
-      const action1 = createAction('ACTION_1');
-      const reducer = handleAction(
-        action1,
-        (state) => state
-      );
+      const reducer = handleAction(createAction('ACTION_1'), identity);
       expect(() => reducer(undefined))
       // eslint-disable-next-line max-len
         .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
     });
 
     it('should throw a descriptive error when the action type is missing', () => {
-      const action1 = createAction('ACTION_1');
-      const reducer = handleAction(
-        action1,
-        (state) => state
-      );
+      const reducer = handleAction(createAction('ACTION_1'), identity);
       expect(() => reducer(undefined, {}))
       // eslint-disable-next-line max-len
         .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);
     });
 
     it('should throw a descriptive error when the action type is not a string or symbol', () => {
-      const action1 = createAction('ACTION_1');
-      const reducer = handleAction(
-        action1,
-        (state) => state
-      );
+      const reducer = handleAction(createAction('ACTION_1'), identity);
       expect(() => reducer(undefined, { type: false }))
       // eslint-disable-next-line max-len
         .to.throw(/The FSA spec mandates an action object with a type. Try using the createAction\(s\) method./);

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,9 +1,9 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
-import isString from 'lodash/isString';
-import isSymbol from 'lodash/isSymbol';
 import includes from 'lodash/includes';
+import invariant from 'invariant';
+import { isFSA } from 'flux-standard-action';
 import { ACTION_TYPE_DELIMITER } from './combineActions';
 
 export default function handleAction(actionType, reducers, defaultState) {
@@ -14,9 +14,10 @@ export default function handleAction(actionType, reducers, defaultState) {
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
-    if (!isValidFSA(action)) {
-      throw new Error('The FSA spec mandates an action object with a type. Try using the createAction(s) method.');
-    }
+    invariant(
+      isFSA(action),
+      'The FSA spec mandates an action object with a type. Try using the createAction(s) method.'
+    );
 
     if (!includes(actionTypes, action.type.toString())) {
       return state;
@@ -24,8 +25,4 @@ export default function handleAction(actionType, reducers, defaultState) {
 
     return (action.error === true ? throwReducer : nextReducer)(state, action);
   };
-}
-
-function isValidFSA(action) {
-  return !!action && (isString(action.type) || isSymbol(action.type));
 }

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -1,6 +1,8 @@
 import isFunction from 'lodash/isFunction';
 import identity from 'lodash/identity';
 import isNil from 'lodash/isNil';
+import isString from 'lodash/isString';
+import isSymbol from 'lodash/isSymbol';
 import includes from 'lodash/includes';
 import { ACTION_TYPE_DELIMITER } from './combineActions';
 
@@ -12,10 +14,18 @@ export default function handleAction(actionType, reducers, defaultState) {
     : [reducers.next, reducers.throw].map(reducer => (isNil(reducer) ? identity : reducer));
 
   return (state = defaultState, action) => {
+    if (!isValidFSA(action)) {
+      throw new Error('The FSA spec mandates an action object with a type. Try using the createAction(s) method.');
+    }
+
     if (!includes(actionTypes, action.type.toString())) {
       return state;
     }
 
     return (action.error === true ? throwReducer : nextReducer)(state, action);
   };
+}
+
+function isValidFSA(action) {
+  return !!action && (isString(action.type) || isSymbol(action.type));
 }


### PR DESCRIPTION
@yangmillstheory this might be redundant or overkill so feel free to close - but it might be helpful to folks like me to see a more descriptive error when we forget the action type (with the helpful suggestion to use `creatAction` or `createAction(s)`)

~~I also took the liberty of adding an `.editorconfig` and ignoring the JetBrains `.idea` folder. And removing Node 5 from testing since it's past it's useful life. If any of these bother you I can quickly rebase this and take those changes out.~~

Resolves #145.