### PR TITLE
chore(travis): Test against latest Node LTS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "6"
   - "4"
-
 script:
   - npm run lint
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+sudo: false
 language: node_js
 node_js:
   - "6"
-  - "5"
   - "4"
+
 script:
   - npm run lint
   - npm test


### PR DESCRIPTION
Since Node 5 is past its useful life, speed up the build process by just
specifying LTS versions 4 and 6.