### PR TITLE
Remove FSA check in handleAction(s)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "eslint-config-airbnb-base": "^1.0.3",
     "eslint-plugin-import": "^1.5.0",
     "eslint-watch": "^2.1.13",
+    "flux-standard-action": "^1.0.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.5.3",
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "flux-standard-action": "^1.0.0",
     "invariant": "^2.2.1",
     "lodash": "^4.13.1",
     "reduce-reducers": "^0.1.0"

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import identity from 'lodash/identity';
 import { handleAction, createAction, createActions, combineActions } from '../';
 
 describe('handleAction()', () => {
@@ -95,6 +94,20 @@ describe('handleAction()', () => {
           .to.deep.equal({
             counter: 7
           });
+      });
+
+      it('should not throw and return state when action is non-FSA', () => {
+        const reducer = handleAction(type, (state) => state, defaultState);
+        const action = {
+          foo: {
+            bar: 'baz'
+          }
+        };
+
+        expect(reducer(undefined, action)).not.to.throw;
+        expect(reducer(undefined, action)).to.deep.equal({
+          counter: 0
+        });
       });
     });
   });
@@ -237,38 +250,6 @@ describe('handleAction()', () => {
         .to.deep.equal({ number: 2 });
       expect(reducer({ number: 0 }, { type: Symbol('ACTION_3'), payload: 3 }))
         .to.deep.equal({ number: 3 });
-    });
-  });
-
-  describe('with invalid actions', () => {
-    it('should throw a descriptive error when the action object is missing', () => {
-      const reducer = handleAction(createAction('ACTION_1'), identity, {});
-      expect(
-        () => reducer(undefined)
-      ).to.throw(
-        Error,
-        'The FSA spec mandates an action object with a type. Try using the createAction(s) method.'
-      );
-    });
-
-    it('should throw a descriptive error when the action type is missing', () => {
-      const reducer = handleAction(createAction('ACTION_1'), identity, {});
-      expect(
-        () => reducer(undefined, {})
-      ).to.throw(
-        Error,
-        'The FSA spec mandates an action object with a type. Try using the createAction(s) method.'
-      );
-    });
-
-    it('should throw a descriptive error when the action type is not a string or symbol', () => {
-      const reducer = handleAction(createAction('ACTION_1'), identity, {});
-      expect(
-        () => reducer(undefined, { type: false })
-      ).to.throw(
-        Error,
-        'The FSA spec mandates an action object with a type. Try using the createAction(s) method.'
-      );
     });
   });
 });

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -5,7 +5,6 @@ import isNil from 'lodash/isNil';
 import isUndefined from 'lodash/isUndefined';
 import includes from 'lodash/includes';
 import invariant from 'invariant';
-import { isFSA } from 'flux-standard-action';
 import { ACTION_TYPE_DELIMITER } from './combineActions';
 
 export default function handleAction(actionType, reducer = identity, defaultState) {
@@ -24,12 +23,8 @@ export default function handleAction(actionType, reducer = identity, defaultStat
     : [reducer.next, reducer.throw].map(aReducer => (isNil(aReducer) ? identity : aReducer));
 
   return (state = defaultState, action) => {
-    invariant(
-      isFSA(action),
-      'The FSA spec mandates an action object with a type. Try using the createAction(s) method.'
-    );
-
-    if (!includes(actionTypes, action.type.toString())) {
+    const { type } = action;
+    if (type && !includes(actionTypes, type.toString())) {
       return state;
     }
 


### PR DESCRIPTION
With #141 we have made other libraries incompatible with redux-actions and it resulted to an unexpected behavior (#164, #167). If an action is not a FSA, handleAction should not handle it and just pass it to the next reducer. This fix will remove the FSA check to support Non-FSA.

Closes #164, #167