### PR TITLE
Support namespacing action creators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
     "no-unused-expressions": 0,
     "no-param-reassign": 0,
     "no-reserved-keys": 0,
-    "space-infix-ops": 0
+    "space-infix-ops": 0,
+    "new-cap": 0,
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,6 @@
     "no-unused-expressions": 0,
     "no-param-reassign": 0,
     "no-reserved-keys": 0,
-    "space-infix-ops": 0,
-    "new-cap": 0,
+    "space-infix-ops": 0
   }
 }

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ expect(actionThree(3)).to.deep.equal({
 });
 ```
 
-If `actionsMap` has a recursive structure, its leaves are used as payload and meta creators, and the action type for each leaf the combined path to that leaf, given an optional prefix:
+If `actionsMap` has a recursive structure, its leaves are used as payload and meta creators, and the action type for each leaf is the combined path to that leaf, given an optional prefix:
 
 ```js
 const actionCreators = createActions({

--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ const reducer = handleActions({
 }, { counter: 0 });
 ```
 
-### `combineActions(...actionTypes)`
+### `combineActions(...types)`
 
-Combine any number of action types or action creators. `actionTypes` is a list of positional arguments which can be action type strings, symbols, or action creators.
+Combine any number of action types or action creators. `types` is a list of positional arguments which can be action type strings, symbols, or action creators.
 
 This allows you to reduce multiple distinct actions with the same reducer.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ expect(actionThree(3)).to.deep.equal({
 });
 ```
 
-If `actionsMap` has a recursive structure, its leaves are used as payload and meta creators, and the action type for each leaf is the combined path to that leaf, given an optional prefix:
+If `actionsMap` has a recursive structure, its leaves are used as payload and meta creators, and the action type for each leaf is the combined path to that leaf:
 
 ```js
 const actionCreators = createActions({
@@ -172,7 +172,7 @@ expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equa
   meta: { username: 'yangmillstheory', message: 'Hello World' }
 });
 ```
-When using this form, you can pass an object with key `namespace` to use your own namespace, instead of the default `/`.
+When using this form, you can pass an object with key `namespace` as the last positional argument, instead of the default `/`.
 
 ### `handleAction(type, reducer | reducerMap = Identity, defaultState)`
 

--- a/README.md
+++ b/README.md
@@ -89,20 +89,20 @@ createAction('ADD_TODO')('Use Redux');
 
 `metaCreator` is an optional function that creates metadata for the payload. It receives the same arguments as the payload creator, but its result becomes the meta field of the resulting action. If `metaCreator` is undefined or not a function, the meta field is omitted.
 
-### `createActions(?actionsMap, ?...identityActions)`
+### `createActions(?actionMap, ?...identityActions)`
 
 ```js
 import { createActions } from 'redux-actions';
 ```
 
-Returns an object mapping action types to action creators. The keys of this object are camel-cased from the keys in `actionsMap` and the string literals of `identityActions`; the values are the action creators.
+Returns an object mapping action types to action creators. The keys of this object are camel-cased from the keys in `actionMap` and the string literals of `identityActions`; the values are the action creators.
 
-`actionsMap` is an optional object and a recursive data structure, with action types as keys, and whose values **must** be either
+`actionMap` is an optional object and a recursive data structure, with action types as keys, and whose values **must** be either
 
 - a function, which is the payload creator for that action
 - an array with `payload` and `meta` functions in that order, as in [`createAction`](#createactiontype-payloadcreator--identity-metacreator)
     - `meta` is **required** in this case (otherwise use the function form above)
-- an `actionsMap`
+- an `actionMap`
 
 `identityActions` is an optional list of positional string arguments that are action type strings; these action types will use the identity payload creator.
 
@@ -138,7 +138,7 @@ expect(actionThree(3)).to.deep.equal({
 });
 ```
 
-If `actionsMap` has a recursive structure, its leaves are used as payload and meta creators, and the action type for each leaf is the combined path to that leaf:
+If `actionMap` has a recursive structure, its leaves are used as payload and meta creators, and the action type for each leaf is the combined path to that leaf:
 
 ```js
 const actionCreators = createActions({

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Returns an object mapping action types to action creators. The keys of this obje
 - a function, which is the payload creator for that action
 - an array with `payload` and `meta` functions in that order, as in [`createAction`](#createactiontype-payloadcreator--identity-metacreator)
     - `meta` is **required** in this case (otherwise use the function form above)
-- actions maps
+- an `actionsMap`
 
 `identityActions` is an optional list of positional string arguments that are action type strings; these action types will use the identity payload creator.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-actions",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "description": "Flux Standard Action utlities for Redux",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-actions",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Flux Standard Action utlities for Redux",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/__tests__/combineActions-test.js
+++ b/src/__tests__/combineActions-test.js
@@ -13,12 +13,9 @@ describe('combineActions', () => {
   it('should accept action creators and action type strings', () => {
     const { action1, action2 } = createActions('ACTION_1', 'ACTION_2');
 
-    expect(() => combineActions('ACTION_1', 'ACTION_2'))
-      .not.to.throw(Error);
-    expect(() => combineActions(action1, action2))
-      .not.to.throw(Error);
-    expect(() => combineActions(action1, action2, 'ACTION_3'))
-      .not.to.throw(Error);
+    expect(() => combineActions('ACTION_1', 'ACTION_2')).not.to.throw(Error);
+    expect(() => combineActions(action1, action2)).not.to.throw(Error);
+    expect(() => combineActions(action1, action2, 'ACTION_3')).not.to.throw(Error);
   });
 
   it('should return a stringifiable object', () => {

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -228,6 +228,26 @@ describe('createActions', () => {
     expect(actionCreators.app.counter.increment(1)).to.deep.equal({
       type: 'APP/COUNTER/INCREMENT',
       payload: { amount: 1 }
-    })
+    });
+    expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
+      type: 'APP/COUNTER/DECREMENT',
+      payload: { amount: -1 }
+    });
+    expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
+      type: 'APP/NOTIFY',
+      payload: { message: 'yangmillstheory: Hello World' }
+    });
+    expect(actionCreators.login('yangmillstheory')).to.deep.equal({
+      type: 'LOGIN',
+      payload: { username: 'yangmillstheory' }
+    });
+    expect(actionCreators.actionOne('one')).to.deep.equal({
+      type: 'ACTION_ONE',
+      payload: 'one'
+    });
+    expect(actionCreators.actionTwo('two')).to.deep.equal({
+      type: 'ACTION_TWO',
+      payload: 'two'
+    });
   });
 });

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -11,13 +11,6 @@ describe('createActions', () => {
   });
 
   it('should throw an error when given bad payload creators', () => {
-    // expect(
-    //   () => createActions({ ACTION_1: {} })
-    // ).to.throw(
-    //   Error,
-    //   'Expected function, undefined, or array with payload and meta functions for ACTION_1'
-    // );
-
     expect(
       () => createActions({
         ACTION_1: () => {},
@@ -106,16 +99,16 @@ describe('createActions', () => {
   });
 
   it('should honor special delimiters in action types', () => {
-    const { 'p/actionOne': pActionOne, 'q/actionTwo': qActionTwo } = createActions({
+    const { p: { actionOne }, q: { actionTwo } } = createActions({
       'P/ACTION_ONE': (key, value) => ({ [key]: value }),
       'Q/ACTION_TWO': (first, second) => ([first, second])
     });
 
-    expect(pActionOne('value', 1)).to.deep.equal({
+    expect(actionOne('value', 1)).to.deep.equal({
       type: 'P/ACTION_ONE',
       payload: { value: 1 }
     });
-    expect(qActionTwo('value', 2)).to.deep.equal({
+    expect(actionTwo('value', 2)).to.deep.equal({
       type: 'Q/ACTION_TWO',
       payload: ['value', 2]
     });
@@ -265,7 +258,7 @@ describe('createActions', () => {
           (username, message) => ({ message: `${username}: ${message}` }),
           (username, message) => ({ username, message })
         ]
-      },
+      }
     });
 
     expect(actionCreators.app.counter.increment(1)).to.deep.equal({
@@ -298,7 +291,7 @@ describe('createActions', () => {
           (username, message) => ({ message: `${username}: ${message}` }),
           (username, message) => ({ username, message })
         ]
-      },
+      }
     }, { namespace: '--' });
 
     console.log(actionCreators);

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -212,4 +212,22 @@ describe('createActions', () => {
       payload: 4
     });
   });
+
+  it('should create actions from a namespaced actions map', () => {
+    const actionCreators = createActions({
+      APP: {
+        COUNTER: {
+          INCREMENT: amount => ({ amount }),
+          DECREMENT: amount => ({ amount: -amount })
+        },
+        NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
+      },
+      LOGIN: username => ({ username })
+    }, 'ACTION_ONE', 'ACTION_TWO');
+
+    expect(actionCreators.app.counter.increment(1)).to.deep.equal({
+      type: 'APP/COUNTER/INCREMENT',
+      payload: { amount: 1 },
+    })
+  });
 });

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -244,7 +244,7 @@ describe('createActions', () => {
     });
   });
 
-  it('should create namesped actions with payload creators in array form', () => {
+  it('should create namespaced actions with payload creators in array form', () => {
     const actionCreators = createActions({
       APP: {
         COUNTER: {

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -178,7 +178,7 @@ describe('createActions', () => {
     });
   });
 
-  it('should create actions from an actions map and action types', () => {
+  it('should create actions from an action map and action types', () => {
     const { action1, action2, action3, action4 } = createActions({
       ACTION_1: (key, value) => ({ [key]: value }),
       ACTION_2: [
@@ -206,7 +206,7 @@ describe('createActions', () => {
     });
   });
 
-  it('should create actions from a namespaced actions map', () => {
+  it('should create actions from a namespaced action map', () => {
     const actionCreators = createActions({
       APP: {
         COUNTER: {

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -227,7 +227,7 @@ describe('createActions', () => {
 
     expect(actionCreators.app.counter.increment(1)).to.deep.equal({
       type: 'APP/COUNTER/INCREMENT',
-      payload: { amount: 1 },
+      payload: { amount: 1 }
     })
   });
 });

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -250,4 +250,37 @@ describe('createActions', () => {
       payload: 'two'
     });
   });
+
+  it('should create actions with payload creators in array form', () => {
+    const actionCreators = createActions({
+      APP: {
+        COUNTER: {
+          INCREMENT: [
+            amount => ({ amount }),
+            amount => ({ key: 'value' })
+          ],
+          DECREMENT: amount => ({ amount: -amount })
+        },
+        NOTIFY: [
+          (username, message) => ({ message: `${username}: ${message}` }),
+          (username, message) => ({ username, message })
+        ]
+      },
+    });
+
+    expect(actionCreators.app.counter.increment(1)).to.deep.equal({
+      type: 'APP/COUNTER/INCREMENT',
+      payload: { amount: 1 },
+      meta: { key: 'value' }
+    });
+    expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
+      type: 'APP/COUNTER/DECREMENT',
+      payload: { amount: -1 }
+    });
+    expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
+      type: 'APP/NOTIFY',
+      payload: { message: 'yangmillstheory: Hello World' },
+      meta: { username: 'yangmillstheory', message: 'Hello World' }
+    });
+  });
 });

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -11,12 +11,12 @@ describe('createActions', () => {
   });
 
   it('should throw an error when given bad payload creators', () => {
-    expect(
-      () => createActions({ ACTION_1: {} })
-    ).to.throw(
-      Error,
-      'Expected function, undefined, or array with payload and meta functions for ACTION_1'
-    );
+    // expect(
+    //   () => createActions({ ACTION_1: {} })
+    // ).to.throw(
+    //   Error,
+    //   'Expected function, undefined, or array with payload and meta functions for ACTION_1'
+    // );
 
     expect(
       () => createActions({

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -294,7 +294,6 @@ describe('createActions', () => {
       }
     }, { namespace: '--' });
 
-    console.log(actionCreators);
     expect(actionCreators.app.counter.increment(1)).to.deep.equal({
       type: 'APP--COUNTER--INCREMENT',
       payload: { amount: 1 },

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -251,13 +251,13 @@ describe('createActions', () => {
     });
   });
 
-  it('should create actions with payload creators in array form', () => {
+  it('should create namesped actions with payload creators in array form', () => {
     const actionCreators = createActions({
       APP: {
         COUNTER: {
           INCREMENT: [
             amount => ({ amount }),
-            amount => ({ key: 'value' })
+            amount => ({ key: 'value', amount })
           ],
           DECREMENT: amount => ({ amount: -amount })
         },
@@ -271,7 +271,7 @@ describe('createActions', () => {
     expect(actionCreators.app.counter.increment(1)).to.deep.equal({
       type: 'APP/COUNTER/INCREMENT',
       payload: { amount: 1 },
-      meta: { key: 'value' }
+      meta: { key: 'value', amount: 1 }
     });
     expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
       type: 'APP/COUNTER/DECREMENT',
@@ -279,6 +279,40 @@ describe('createActions', () => {
     });
     expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
       type: 'APP/NOTIFY',
+      payload: { message: 'yangmillstheory: Hello World' },
+      meta: { username: 'yangmillstheory', message: 'Hello World' }
+    });
+  });
+
+  it('should create namespaced actions with a chosen namespace string', () => {
+    const actionCreators = createActions({
+      APP: {
+        COUNTER: {
+          INCREMENT: [
+            amount => ({ amount }),
+            amount => ({ key: 'value', amount })
+          ],
+          DECREMENT: amount => ({ amount: -amount })
+        },
+        NOTIFY: [
+          (username, message) => ({ message: `${username}: ${message}` }),
+          (username, message) => ({ username, message })
+        ]
+      },
+    }, { namespace: '--' });
+
+    console.log(actionCreators);
+    expect(actionCreators.app.counter.increment(1)).to.deep.equal({
+      type: 'APP--COUNTER--INCREMENT',
+      payload: { amount: 1 },
+      meta: { key: 'value', amount: 1 }
+    });
+    expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
+      type: 'APP--COUNTER--DECREMENT',
+      payload: { amount: -1 }
+    });
+    expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
+      type: 'APP--NOTIFY',
       payload: { message: 'yangmillstheory: Hello World' },
       meta: { username: 'yangmillstheory', message: 'Hello World' }
     });

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -184,4 +184,56 @@ describe('handleActions', () => {
         counter: 7
       });
   });
+
+  it('should work with namespaced actions', () => {
+    const {
+      app: {
+        counter: {
+          increment,
+          decrement
+        },
+        notify
+      }
+    } = createActions({
+      APP: {
+        COUNTER: {
+          INCREMENT: [
+            amount => ({ amount }),
+            amount => ({ key: 'value', amount })
+          ],
+          DECREMENT: amount => ({ amount: -amount })
+        },
+        NOTIFY: [
+          (username, message) => ({ message: `${username}: ${message}` }),
+          (username, message) => ({ username, message })
+        ]
+      }
+    });
+
+    // note: we should be using combineReducers in production, but this is just a test
+    const reducer = handleActions({
+      [combineActions(increment, decrement)]: ({ counter, message }, { payload: { amount } }) => ({
+        counter: counter + amount,
+        message
+      }),
+
+      [notify]: ({ counter, message }, { payload }) => ({
+        counter,
+        message: `${message}---${payload.message}`
+      })
+    }, { counter: 0, message: '' });
+
+    expect(reducer({ counter: 3, message: 'hello' }, increment(2))).to.deep.equal({
+      counter: 5,
+      message: 'hello'
+    });
+    expect(reducer({ counter: 10, message: 'hello' }, decrement(3))).to.deep.equal({
+      counter: 7,
+      message: 'hello'
+    });
+    expect(reducer({ counter: 10, message: 'hello' }, notify('me', 'goodbye'))).to.deep.equal({
+      counter: 10,
+      message: 'hello---me: goodbye'
+    });
+  });
 });

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -1,0 +1,89 @@
+/* global describe, it, beforeEach */
+import {nestActions, unnestActions} from './index'
+import {createActions} from 'redux-actions'
+import {expect} from 'chai'
+
+describe('createActions', () => {
+  describe('scoping', () => {
+    const actionsMap = {
+      'APP/COUNTER/INCREMENT': amount => ({amount}),
+      'APP/COUNTER/DECREMENT': amount => ({amount: -amount}),
+      'APP/NOTIFY': (username, message) => ({message: `${username}: ${message}`}),
+      LOGIN: username => ({username}),
+    }
+    let actionCreators
+
+    beforeEach(() => {
+      actionCreators = unnestActions(createActions(actionsMap, 'LOGOUT'))
+    })
+
+    it('should create top-level action creators', () => {
+      expect(actionCreators.login('yangmillstheory')).to.deep.equal({
+        type: 'LOGIN',
+        payload: {username: 'yangmillstheory'},
+      })
+      expect(actionCreators.logout()).to.deep.equal({type: 'LOGOUT'})
+    })
+
+    it('should create child action creators', () => {
+      expect(actionCreators.app.notify('yangmillstheory', 'Hello, World!'))
+        .to.deep.equal({
+          type: 'APP/NOTIFY',
+          message: 'yangmillstheory: Hello, World!',
+        })
+    })
+
+    it('should create deeply nested action creators', () => {
+      expect(actionCreators.app.counter.increment(1)).to.deep.equal({
+        type: 'APP/COUNTER/INCREMENT',
+        amount: 1,
+      })
+      expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
+        type: 'APP/COUNTER/DECREMENT',
+        amount: -1,
+      })
+    })
+  })
+
+  describe('packing', () => {
+    it('should pack actions', () => {
+      const unnestedActions = {
+        APP: {
+          COUNTER: {
+            INCREMENT: amount => ({amount}),
+            DECREMENT: amount => ({amount: -amount}),
+          },
+          NOTIFY: (username, message) => ({message: `${username}: ${message}`}),
+        },
+        LOGIN: username => ({username}),
+      }
+
+      expect(nestActions(unnestedActions)).to.deep.equal({
+        'APP/COUNTER/INCREMENT': unnestedActions.APP.COUNTER.INCREMENT,
+        'APP/COUNTER/DECREMENT': unnestedActions.APP.COUNTER.DECREMENT,
+        'APP/NOTIFY': unnestedActions.APP.NOTIFY,
+        'LOGIN': unnestedActions.LOGIN,
+      })
+    })
+
+    it('should be case insensitive', () => {
+      const unnestedActions = {
+        app: {
+          counter: {
+            increment: amount => ({amount}),
+            decrement: amount => ({amount: -amount}),
+          },
+          notify: (username, message) => ({message: `${username}: ${message}`}),
+        },
+        login: username => ({username}),
+      }
+
+      expect(nestActions(unnestedActions)).to.deep.equal({
+        'app/counter/increment': unnestedActions.app.counter.increment,
+        'app/counter/decrement': unnestedActions.app.counter.decrement,
+        'app/notify': unnestedActions.app.notify,
+        'login': unnestedActions.login,
+      })
+    })
+  })
+})

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -79,6 +79,8 @@ describe('unflattenActions', () => {
     expect(actionsMap.LOGIN('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
     expect(actionsMap.APP.COUNTER.INCREMENT(100)).to.deep.equal({ amount: 100 });
     expect(actionsMap.APP.COUNTER.DECREMENT(100)).to.deep.equal({ amount: -100 });
-    expect(actionsMap.APP.NOTIFY('yangmillstheory', 'Hello World')).to.deep.equal({ message: 'yangmillstheory: Hello World' });
+    expect(actionsMap.APP.NOTIFY('yangmillstheory', 'Hello World')).to.deep.equal({
+      message: 'yangmillstheory: Hello World'
+    });
   });
 });

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -93,4 +93,20 @@ describe('unflattenActions', () => {
     expect(actionsMap.APP.COUNTER.INCREMENT(100)).to.deep.equal({ amount: 100 });
     expect(actionsMap.APP.COUNTER.DECREMENT(100)).to.deep.equal({ amount: -100 });
   });
+
+  it('should do nothing to an already unflattened map', () => {
+    const actionsMap = {
+      APP: {
+        COUNTER: {
+          INCREMENT: amount => ({ amount }),
+          DECREMENT: amount => ({ amount: -amount })
+        },
+        NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
+      },
+      LOGIN: username => ({ username })
+    };
+    const unflattenedActionsMap = unflattenActions(actionsMap);
+
+    expect(unflattenedActionsMap).to.deep.equal(actionsMap);
+  });
 });

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -1,9 +1,9 @@
-import { flattenActions, unflattenActions } from '../namespaceActions';
+import { flattenActionsMap, unflattenActionCreators } from '../namespaceActions';
 import { expect } from 'chai';
 
 describe('namespacing actions', () => {
-  describe('flattenActions', () => {
-    it('should flatten an action creators map with the default namespacer', () => {
+  describe('flattenActionsMap', () => {
+    it('should flatten an actions map with the default namespacer', () => {
       const actionsMap = {
         APP: {
           COUNTER: {
@@ -15,7 +15,7 @@ describe('namespacing actions', () => {
         LOGIN: username => ({ username })
       };
 
-      expect(flattenActions(actionsMap)).to.deep.equal({
+      expect(flattenActionsMap(actionsMap)).to.deep.equal({
         'APP/COUNTER/INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
         'APP/COUNTER/DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
         'APP/NOTIFY': actionsMap.APP.NOTIFY,
@@ -30,7 +30,7 @@ describe('namespacing actions', () => {
         LOGIN: username => ({ username })
       };
 
-      expect(flattenActions(actionsMap)).to.deep.equal(actionsMap);
+      expect(flattenActionsMap(actionsMap)).to.deep.equal(actionsMap);
     });
 
     it('should be case-sensitive', () => {
@@ -45,7 +45,7 @@ describe('namespacing actions', () => {
         login: username => ({ username })
       };
 
-      expect(flattenActions(actionsMap)).to.deep.equal({
+      expect(flattenActionsMap(actionsMap)).to.deep.equal({
         'app/counter/increment': actionsMap.app.counter.increment,
         'app/counter/decrement': actionsMap.app.counter.decrement,
         'app/notify': actionsMap.app.notify,
@@ -65,7 +65,7 @@ describe('namespacing actions', () => {
         LOGIN: username => ({ username })
       };
 
-      expect(flattenActions(actionsMap, '-')).to.deep.equal({
+      expect(flattenActionsMap(actionsMap, '-')).to.deep.equal({
         'APP-COUNTER-INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
         'APP-COUNTER-DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
         'APP-NOTIFY': actionsMap.APP.NOTIFY,
@@ -74,9 +74,9 @@ describe('namespacing actions', () => {
     });
   });
 
-  describe('unflattenActions', () => {
-    it('should unflatten a flattened actions map and camel-case keys', () => {
-      const actionsMap = unflattenActions({
+  describe('unflattenActionCreators', () => {
+    it('should unflatten a flattened action creators map and camel-case keys', () => {
+      const actionsMap = unflattenActionCreators({
         'APP/COUNTER/INCREMENT': amount => ({ amount }),
         'APP/COUNTER/DECREMENT': amount => ({ amount: -amount }),
         'APP/NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
@@ -91,8 +91,8 @@ describe('namespacing actions', () => {
       expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
     });
 
-    it('should unflatten a flattened actions map with custom namespace', () => {
-      const actionsMap = unflattenActions({
+    it('should unflatten a flattened action creators map with custom namespace', () => {
+      const actionsMap = unflattenActionCreators({
         'APP--COUNTER--INCREMENT': amount => ({ amount }),
         'APP--COUNTER--DECREMENT': amount => ({ amount: -amount }),
         'APP--NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -73,10 +73,10 @@ describe('unflattenActions', () => {
     });
 
     expect(actionsMap.LOGIN('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
-    expect(actionsMap.APP.COUNTER.INCREMENT(100)).to.deep.equal({ amount: 100 });
-    expect(actionsMap.APP.COUNTER.DECREMENT(100)).to.deep.equal({ amount: -100 });
     expect(actionsMap.APP.NOTIFY('yangmillstheory', 'Hello World')).to.deep.equal({
       message: 'yangmillstheory: Hello World'
     });
+    expect(actionsMap.APP.COUNTER.INCREMENT(100)).to.deep.equal({ amount: 100 });
+    expect(actionsMap.APP.COUNTER.DECREMENT(100)).to.deep.equal({ amount: -100 });
   });
 });

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -36,7 +36,7 @@ describe('flattenActions', () => {
     });
   });
 
-  it('should be case-sensitive', () => {
+  it('should be case-insensitive', () => {
     const actionsMap = {
       app: {
         counter: {
@@ -86,27 +86,27 @@ describe('unflattenActions', () => {
       LOGIN: username => ({ username })
     });
 
-    expect(actionsMap.LOGIN('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
-    expect(actionsMap.APP.NOTIFY('yangmillstheory', 'Hello World')).to.deep.equal({
+    expect(actionsMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
+    expect(actionsMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
       message: 'yangmillstheory: Hello World'
     });
-    expect(actionsMap.APP.COUNTER.INCREMENT(100)).to.deep.equal({ amount: 100 });
-    expect(actionsMap.APP.COUNTER.DECREMENT(100)).to.deep.equal({ amount: -100 });
+    expect(actionsMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
+    expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
   });
 
-  it('should do nothing to an already unflattened map', () => {
-    const actionsMap = {
-      APP: {
-        COUNTER: {
-          INCREMENT: amount => ({ amount }),
-          DECREMENT: amount => ({ amount: -amount })
-        },
-        NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
-      },
+  it('should unflatten a flattened actions map with custom namespace', () => {
+    const actionsMap = unflattenActions({
+      'APP--COUNTER--INCREMENT': amount => ({ amount }),
+      'APP--COUNTER--DECREMENT': amount => ({ amount: -amount }),
+      'APP--NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
       LOGIN: username => ({ username })
-    };
-    const unflattenedActionsMap = unflattenActions(actionsMap);
+    }, '--');
 
-    expect(unflattenedActionsMap).to.deep.equal(actionsMap);
+    expect(actionsMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
+    expect(actionsMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
+      message: 'yangmillstheory: Hello World'
+    });
+    expect(actionsMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
+    expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
   });
 });

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -75,7 +75,7 @@ describe('namespacing actions', () => {
   });
 
   describe('unflattenActionCreators', () => {
-    it('should unflatten a flattened action creators map and camel-case keys', () => {
+    it('should unflatten a flattened action map and camel-case keys', () => {
       const actionsMap = unflattenActionCreators({
         'APP/COUNTER/INCREMENT': amount => ({ amount }),
         'APP/COUNTER/DECREMENT': amount => ({ amount: -amount }),
@@ -91,7 +91,7 @@ describe('namespacing actions', () => {
       expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
     });
 
-    it('should unflatten a flattened action creators map with custom namespace', () => {
+    it('should unflatten a flattened action map with custom namespace', () => {
       const actionsMap = unflattenActionCreators({
         'APP--COUNTER--INCREMENT': amount => ({ amount }),
         'APP--COUNTER--DECREMENT': amount => ({ amount: -amount }),

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -64,17 +64,13 @@ describe('flattenActions', () => {
 });
 
 describe('unflattenActions', () => {
-  beforeEach(() => {
-    this.actionsMap = {
+  it('should unflatten a flattened actions map', () => {
+    const actionsMap = unflattenActions({
       'APP/COUNTER/INCREMENT': amount => ({ amount }),
       'APP/COUNTER/DECREMENT': amount => ({ amount: -amount }),
       'APP/NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
       LOGIN: username => ({ username })
-    };
-  });
-
-  it('should unflatten a flattened actions map', () => {
-    const actionsMap = unflattenActions(this.actionsMap);
+    });
 
     expect(actionsMap.LOGIN('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
     expect(actionsMap.APP.COUNTER.INCREMENT(100)).to.deep.equal({ amount: 100 });

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -29,11 +29,7 @@ describe('flattenActions', () => {
       LOGIN: username => ({ username })
     };
 
-    expect(flattenActions(actionsMap)).to.deep.equal({
-      INCREMENT: actionsMap.INCREMENT,
-      DECREMENT: actionsMap.DECREMENT,
-      LOGIN: actionsMap.LOGIN
-    });
+    expect(flattenActions(actionsMap)).to.deep.equal(actionsMap);
   });
 
   it('should be case-sensitive', () => {

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -22,7 +22,21 @@ describe('flattenActions', () => {
     });
   });
 
-  it('should be casesensitive', () => {
+  it('should do nothing to an already flattened map', () => {
+    const actionsMap = {
+      INCREMENT: amount => ({ amount }),
+      DECREMENT: amount => ({ amount: -amount }),
+      LOGIN: username => ({ username })
+    };
+
+    expect(flattenActions(actionsMap)).to.deep.equal({
+      INCREMENT: actionsMap.INCREMENT,
+      DECREMENT: actionsMap.DECREMENT,
+      LOGIN: actionsMap.LOGIN
+    });
+  });
+
+  it('should be case-sensitive', () => {
     const actionsMap = {
       app: {
         counter: {

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -1,89 +1,84 @@
-/* global describe, it, beforeEach */
-import {nestActions, unnestActions} from './index'
-import {createActions} from 'redux-actions'
-import {expect} from 'chai'
+import { flattenActions, unflattenActions } from '../namespaceActions';
+import { expect } from 'chai';
 
-describe('createActions', () => {
-  describe('scoping', () => {
+describe('flattenActions', () => {
+  it('should flatten an action creators map with the default namespacer', () => {
     const actionsMap = {
-      'APP/COUNTER/INCREMENT': amount => ({amount}),
-      'APP/COUNTER/DECREMENT': amount => ({amount: -amount}),
-      'APP/NOTIFY': (username, message) => ({message: `${username}: ${message}`}),
-      LOGIN: username => ({username}),
-    }
-    let actionCreators
-
-    beforeEach(() => {
-      actionCreators = unnestActions(createActions(actionsMap, 'LOGOUT'))
-    })
-
-    it('should create top-level action creators', () => {
-      expect(actionCreators.login('yangmillstheory')).to.deep.equal({
-        type: 'LOGIN',
-        payload: {username: 'yangmillstheory'},
-      })
-      expect(actionCreators.logout()).to.deep.equal({type: 'LOGOUT'})
-    })
-
-    it('should create child action creators', () => {
-      expect(actionCreators.app.notify('yangmillstheory', 'Hello, World!'))
-        .to.deep.equal({
-          type: 'APP/NOTIFY',
-          message: 'yangmillstheory: Hello, World!',
-        })
-    })
-
-    it('should create deeply nested action creators', () => {
-      expect(actionCreators.app.counter.increment(1)).to.deep.equal({
-        type: 'APP/COUNTER/INCREMENT',
-        amount: 1,
-      })
-      expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
-        type: 'APP/COUNTER/DECREMENT',
-        amount: -1,
-      })
-    })
-  })
-
-  describe('packing', () => {
-    it('should pack actions', () => {
-      const unnestedActions = {
-        APP: {
-          COUNTER: {
-            INCREMENT: amount => ({amount}),
-            DECREMENT: amount => ({amount: -amount}),
-          },
-          NOTIFY: (username, message) => ({message: `${username}: ${message}`}),
+      APP: {
+        COUNTER: {
+          INCREMENT: amount => ({ amount }),
+          DECREMENT: amount => ({ amount: -amount })
         },
-        LOGIN: username => ({username}),
-      }
+        NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
+      },
+      LOGIN: username => ({ username })
+    };
 
-      expect(nestActions(unnestedActions)).to.deep.equal({
-        'APP/COUNTER/INCREMENT': unnestedActions.APP.COUNTER.INCREMENT,
-        'APP/COUNTER/DECREMENT': unnestedActions.APP.COUNTER.DECREMENT,
-        'APP/NOTIFY': unnestedActions.APP.NOTIFY,
-        'LOGIN': unnestedActions.LOGIN,
-      })
-    })
+    expect(flattenActions(actionsMap)).to.deep.equal({
+      'APP/COUNTER/INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
+      'APP/COUNTER/DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
+      'APP/NOTIFY': actionsMap.APP.NOTIFY,
+      LOGIN: actionsMap.LOGIN
+    });
+  });
 
-    it('should be case insensitive', () => {
-      const unnestedActions = {
-        app: {
-          counter: {
-            increment: amount => ({amount}),
-            decrement: amount => ({amount: -amount}),
-          },
-          notify: (username, message) => ({message: `${username}: ${message}`}),
+  it('should be casesensitive', () => {
+    const actionsMap = {
+      app: {
+        counter: {
+          increment: amount => ({ amount }),
+          decrement: amount => ({ amount: -amount })
         },
-        login: username => ({username}),
-      }
+        notify: (username, message) => ({ message: `${username}: ${message}` })
+      },
+      login: username => ({ username })
+    };
 
-      expect(nestActions(unnestedActions)).to.deep.equal({
-        'app/counter/increment': unnestedActions.app.counter.increment,
-        'app/counter/decrement': unnestedActions.app.counter.decrement,
-        'app/notify': unnestedActions.app.notify,
-        'login': unnestedActions.login,
-      })
-    })
-  })
-})
+    expect(flattenActions(actionsMap)).to.deep.equal({
+      'app/counter/increment': actionsMap.app.counter.increment,
+      'app/counter/decrement': actionsMap.app.counter.decrement,
+      'app/notify': actionsMap.app.notify,
+      login: actionsMap.login
+    });
+  });
+
+  it('should use a custom namespace string', () => {
+    const actionsMap = {
+      APP: {
+        COUNTER: {
+          INCREMENT: amount => ({ amount }),
+          DECREMENT: amount => ({ amount: -amount })
+        },
+        NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
+      },
+      LOGIN: username => ({ username })
+    };
+
+    expect(flattenActions(actionsMap, '-')).to.deep.equal({
+      'APP-COUNTER-INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
+      'APP-COUNTER-DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
+      'APP-NOTIFY': actionsMap.APP.NOTIFY,
+      LOGIN: actionsMap.LOGIN
+    });
+  });
+});
+
+describe('unflattenActions', () => {
+  beforeEach(() => {
+    this.actionsMap = {
+      'APP/COUNTER/INCREMENT': amount => ({ amount }),
+      'APP/COUNTER/DECREMENT': amount => ({ amount: -amount }),
+      'APP/NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
+      LOGIN: username => ({ username })
+    };
+  });
+
+  it('should unflatten a flattened actions map', () => {
+    const actionsMap = unflattenActions(this.actionsMap);
+
+    expect(actionsMap.LOGIN('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
+    expect(actionsMap.APP.COUNTER.INCREMENT(100)).to.deep.equal({ amount: 100 });
+    expect(actionsMap.APP.COUNTER.DECREMENT(100)).to.deep.equal({ amount: -100 });
+    expect(actionsMap.APP.NOTIFY('yangmillstheory', 'Hello World')).to.deep.equal({ message: 'yangmillstheory: Hello World' });
+  });
+});

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -1,108 +1,110 @@
 import { flattenActions, unflattenActions } from '../namespaceActions';
 import { expect } from 'chai';
 
-describe('flattenActions', () => {
-  it('should flatten an action creators map with the default namespacer', () => {
-    const actionsMap = {
-      APP: {
-        COUNTER: {
-          INCREMENT: amount => ({ amount }),
-          DECREMENT: amount => ({ amount: -amount })
+describe('namespacing actions', () => {
+  describe('flattenActions', () => {
+    it('should flatten an action creators map with the default namespacer', () => {
+      const actionsMap = {
+        APP: {
+          COUNTER: {
+            INCREMENT: amount => ({ amount }),
+            DECREMENT: amount => ({ amount: -amount })
+          },
+          NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
         },
-        NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
-      },
-      LOGIN: username => ({ username })
-    };
+        LOGIN: username => ({ username })
+      };
 
-    expect(flattenActions(actionsMap)).to.deep.equal({
-      'APP/COUNTER/INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
-      'APP/COUNTER/DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
-      'APP/NOTIFY': actionsMap.APP.NOTIFY,
-      LOGIN: actionsMap.LOGIN
+      expect(flattenActions(actionsMap)).to.deep.equal({
+        'APP/COUNTER/INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
+        'APP/COUNTER/DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
+        'APP/NOTIFY': actionsMap.APP.NOTIFY,
+        LOGIN: actionsMap.LOGIN
+      });
     });
-  });
 
-  it('should do nothing to an already flattened map', () => {
-    const actionsMap = {
-      INCREMENT: amount => ({ amount }),
-      DECREMENT: amount => ({ amount: -amount }),
-      LOGIN: username => ({ username })
-    };
+    it('should do nothing to an already flattened map', () => {
+      const actionsMap = {
+        INCREMENT: amount => ({ amount }),
+        DECREMENT: amount => ({ amount: -amount }),
+        LOGIN: username => ({ username })
+      };
 
-    expect(flattenActions(actionsMap)).to.deep.equal(actionsMap);
-  });
+      expect(flattenActions(actionsMap)).to.deep.equal(actionsMap);
+    });
 
-  it('should be case-sensitive', () => {
-    const actionsMap = {
-      app: {
-        counter: {
-          increment: amount => ({ amount }),
-          decrement: amount => ({ amount: -amount })
+    it('should be case-sensitive', () => {
+      const actionsMap = {
+        app: {
+          counter: {
+            increment: amount => ({ amount }),
+            decrement: amount => ({ amount: -amount })
+          },
+          notify: (username, message) => ({ message: `${username}: ${message}` })
         },
-        notify: (username, message) => ({ message: `${username}: ${message}` })
-      },
-      login: username => ({ username })
-    };
+        login: username => ({ username })
+      };
 
-    expect(flattenActions(actionsMap)).to.deep.equal({
-      'app/counter/increment': actionsMap.app.counter.increment,
-      'app/counter/decrement': actionsMap.app.counter.decrement,
-      'app/notify': actionsMap.app.notify,
-      login: actionsMap.login
+      expect(flattenActions(actionsMap)).to.deep.equal({
+        'app/counter/increment': actionsMap.app.counter.increment,
+        'app/counter/decrement': actionsMap.app.counter.decrement,
+        'app/notify': actionsMap.app.notify,
+        login: actionsMap.login
+      });
     });
-  });
 
-  it('should use a custom namespace string', () => {
-    const actionsMap = {
-      APP: {
-        COUNTER: {
-          INCREMENT: amount => ({ amount }),
-          DECREMENT: amount => ({ amount: -amount })
+    it('should use a custom namespace string', () => {
+      const actionsMap = {
+        APP: {
+          COUNTER: {
+            INCREMENT: amount => ({ amount }),
+            DECREMENT: amount => ({ amount: -amount })
+          },
+          NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
         },
-        NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
-      },
-      LOGIN: username => ({ username })
-    };
+        LOGIN: username => ({ username })
+      };
 
-    expect(flattenActions(actionsMap, '-')).to.deep.equal({
-      'APP-COUNTER-INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
-      'APP-COUNTER-DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
-      'APP-NOTIFY': actionsMap.APP.NOTIFY,
-      LOGIN: actionsMap.LOGIN
+      expect(flattenActions(actionsMap, '-')).to.deep.equal({
+        'APP-COUNTER-INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
+        'APP-COUNTER-DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
+        'APP-NOTIFY': actionsMap.APP.NOTIFY,
+        LOGIN: actionsMap.LOGIN
+      });
     });
   });
-});
 
-describe('unflattenActions', () => {
-  it('should unflatten a flattened actions map', () => {
-    const actionsMap = unflattenActions({
-      'APP/COUNTER/INCREMENT': amount => ({ amount }),
-      'APP/COUNTER/DECREMENT': amount => ({ amount: -amount }),
-      'APP/NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
-      LOGIN: username => ({ username })
+  describe('unflattenActions', () => {
+    it('should unflatten a flattened actions map and camel-case keys', () => {
+      const actionsMap = unflattenActions({
+        'APP/COUNTER/INCREMENT': amount => ({ amount }),
+        'APP/COUNTER/DECREMENT': amount => ({ amount: -amount }),
+        'APP/NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
+        LOGIN: username => ({ username })
+      });
+
+      expect(actionsMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
+      expect(actionsMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
+        message: 'yangmillstheory: Hello World'
+      });
+      expect(actionsMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
+      expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
     });
 
-    expect(actionsMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
-    expect(actionsMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
-      message: 'yangmillstheory: Hello World'
-    });
-    expect(actionsMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
-    expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
-  });
+    it('should unflatten a flattened actions map with custom namespace', () => {
+      const actionsMap = unflattenActions({
+        'APP--COUNTER--INCREMENT': amount => ({ amount }),
+        'APP--COUNTER--DECREMENT': amount => ({ amount: -amount }),
+        'APP--NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
+        LOGIN: username => ({ username })
+      }, '--');
 
-  it('should unflatten a flattened actions map with custom namespace', () => {
-    const actionsMap = unflattenActions({
-      'APP--COUNTER--INCREMENT': amount => ({ amount }),
-      'APP--COUNTER--DECREMENT': amount => ({ amount: -amount }),
-      'APP--NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
-      LOGIN: username => ({ username })
-    }, '--');
-
-    expect(actionsMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
-    expect(actionsMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
-      message: 'yangmillstheory: Hello World'
+      expect(actionsMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
+      expect(actionsMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
+        message: 'yangmillstheory: Hello World'
+      });
+      expect(actionsMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
+      expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
     });
-    expect(actionsMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
-    expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
   });
 });

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -1,10 +1,10 @@
-import { flattenActionsMap, unflattenActionCreators } from '../namespaceActions';
+import { flattenActionMap, unflattenActionCreators } from '../namespaceActions';
 import { expect } from 'chai';
 
 describe('namespacing actions', () => {
-  describe('flattenActionsMap', () => {
-    it('should flatten an actions map with the default namespacer', () => {
-      const actionsMap = {
+  describe('flattenActionMap', () => {
+    it('should flatten an action map with the default namespacer', () => {
+      const actionMap = {
         APP: {
           COUNTER: {
             INCREMENT: amount => ({ amount }),
@@ -15,26 +15,26 @@ describe('namespacing actions', () => {
         LOGIN: username => ({ username })
       };
 
-      expect(flattenActionsMap(actionsMap)).to.deep.equal({
-        'APP/COUNTER/INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
-        'APP/COUNTER/DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
-        'APP/NOTIFY': actionsMap.APP.NOTIFY,
-        LOGIN: actionsMap.LOGIN
+      expect(flattenActionMap(actionMap)).to.deep.equal({
+        'APP/COUNTER/INCREMENT': actionMap.APP.COUNTER.INCREMENT,
+        'APP/COUNTER/DECREMENT': actionMap.APP.COUNTER.DECREMENT,
+        'APP/NOTIFY': actionMap.APP.NOTIFY,
+        LOGIN: actionMap.LOGIN
       });
     });
 
     it('should do nothing to an already flattened map', () => {
-      const actionsMap = {
+      const actionMap = {
         INCREMENT: amount => ({ amount }),
         DECREMENT: amount => ({ amount: -amount }),
         LOGIN: username => ({ username })
       };
 
-      expect(flattenActionsMap(actionsMap)).to.deep.equal(actionsMap);
+      expect(flattenActionMap(actionMap)).to.deep.equal(actionMap);
     });
 
     it('should be case-sensitive', () => {
-      const actionsMap = {
+      const actionMap = {
         app: {
           counter: {
             increment: amount => ({ amount }),
@@ -45,16 +45,16 @@ describe('namespacing actions', () => {
         login: username => ({ username })
       };
 
-      expect(flattenActionsMap(actionsMap)).to.deep.equal({
-        'app/counter/increment': actionsMap.app.counter.increment,
-        'app/counter/decrement': actionsMap.app.counter.decrement,
-        'app/notify': actionsMap.app.notify,
-        login: actionsMap.login
+      expect(flattenActionMap(actionMap)).to.deep.equal({
+        'app/counter/increment': actionMap.app.counter.increment,
+        'app/counter/decrement': actionMap.app.counter.decrement,
+        'app/notify': actionMap.app.notify,
+        login: actionMap.login
       });
     });
 
     it('should use a custom namespace string', () => {
-      const actionsMap = {
+      const actionMap = {
         APP: {
           COUNTER: {
             INCREMENT: amount => ({ amount }),
@@ -65,46 +65,46 @@ describe('namespacing actions', () => {
         LOGIN: username => ({ username })
       };
 
-      expect(flattenActionsMap(actionsMap, '-')).to.deep.equal({
-        'APP-COUNTER-INCREMENT': actionsMap.APP.COUNTER.INCREMENT,
-        'APP-COUNTER-DECREMENT': actionsMap.APP.COUNTER.DECREMENT,
-        'APP-NOTIFY': actionsMap.APP.NOTIFY,
-        LOGIN: actionsMap.LOGIN
+      expect(flattenActionMap(actionMap, '-')).to.deep.equal({
+        'APP-COUNTER-INCREMENT': actionMap.APP.COUNTER.INCREMENT,
+        'APP-COUNTER-DECREMENT': actionMap.APP.COUNTER.DECREMENT,
+        'APP-NOTIFY': actionMap.APP.NOTIFY,
+        LOGIN: actionMap.LOGIN
       });
     });
   });
 
   describe('unflattenActionCreators', () => {
     it('should unflatten a flattened action map and camel-case keys', () => {
-      const actionsMap = unflattenActionCreators({
+      const actionMap = unflattenActionCreators({
         'APP/COUNTER/INCREMENT': amount => ({ amount }),
         'APP/COUNTER/DECREMENT': amount => ({ amount: -amount }),
         'APP/NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
         LOGIN: username => ({ username })
       });
 
-      expect(actionsMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
-      expect(actionsMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
+      expect(actionMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
+      expect(actionMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
         message: 'yangmillstheory: Hello World'
       });
-      expect(actionsMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
-      expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
+      expect(actionMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
+      expect(actionMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
     });
 
     it('should unflatten a flattened action map with custom namespace', () => {
-      const actionsMap = unflattenActionCreators({
+      const actionMap = unflattenActionCreators({
         'APP--COUNTER--INCREMENT': amount => ({ amount }),
         'APP--COUNTER--DECREMENT': amount => ({ amount: -amount }),
         'APP--NOTIFY': (username, message) => ({ message: `${username}: ${message}` }),
         LOGIN: username => ({ username })
       }, '--');
 
-      expect(actionsMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
-      expect(actionsMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
+      expect(actionMap.login('yangmillstheory')).to.deep.equal({ username: 'yangmillstheory' });
+      expect(actionMap.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
         message: 'yangmillstheory: Hello World'
       });
-      expect(actionsMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
-      expect(actionsMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
+      expect(actionMap.app.counter.increment(100)).to.deep.equal({ amount: 100 });
+      expect(actionMap.app.counter.decrement(100)).to.deep.equal({ amount: -100 });
     });
   });
 });

--- a/src/__tests__/namespaceActions-test.js
+++ b/src/__tests__/namespaceActions-test.js
@@ -36,7 +36,7 @@ describe('flattenActions', () => {
     });
   });
 
-  it('should be case-insensitive', () => {
+  it('should be case-sensitive', () => {
     const actionsMap = {
       app: {
         counter: {

--- a/src/arrayToObject.js
+++ b/src/arrayToObject.js
@@ -1,0 +1,4 @@
+export default (array, callback) => array.reduce(
+  (partialObject, element) => callback(partialObject, element),
+  {}
+);

--- a/src/camelCase.js
+++ b/src/camelCase.js
@@ -11,4 +11,4 @@ function camelCase(string) {
   , '');
 }
 
-export default actionType => actionType.split(namespacer).map(camelCase).join(namespacer);
+export default type => type.split(namespacer).map(camelCase).join(namespacer);

--- a/src/combineActions.js
+++ b/src/combineActions.js
@@ -7,15 +7,15 @@ import invariant from 'invariant';
 
 export const ACTION_TYPE_DELIMITER = '||';
 
-function isValidActionType(actionType) {
-  return isString(actionType) || isFunction(actionType) || isSymbol(actionType);
+function isValidActionType(type) {
+  return isString(type) || isFunction(type) || isSymbol(type);
 }
 
-function isValidActionTypes(actionTypes) {
-  if (isEmpty(actionTypes)) {
+function isValidActionTypes(types) {
+  if (isEmpty(types)) {
     return false;
   }
-  return actionTypes.every(isValidActionType);
+  return types.every(isValidActionType);
 }
 
 export default function combineActions(...actionsTypes) {

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -1,12 +1,8 @@
 import identity from 'lodash/identity';
-import camelCase from './camelCase';
 import isPlainObject from 'lodash/isPlainObject';
 import isArray from 'lodash/isArray';
-import every from 'lodash/every';
-import values from 'lodash/values';
 import last from 'lodash/last';
 import isString from 'lodash/isString';
-import isEmpty from 'lodash/isEmpty';
 import isFunction from 'lodash/isFunction';
 import createAction from './createAction';
 import invariant from 'invariant';
@@ -15,7 +11,7 @@ import { defaultNamespace, flattenActions, unflattenActions } from './namespaceA
 export default function createActions(actionsMap, ...identityActions) {
   const namespace = isPlainObject(last(identityActions))
     ? identityActions.pop().namespace
-    : defaultNamespace
+    : defaultNamespace;
   invariant(
     identityActions.every(isString) &&
     (isString(actionsMap) || isPlainObject(actionsMap)),
@@ -43,18 +39,20 @@ function isValidActionsMapValue(actionsMapValue) {
 
 function fromActionsMap(actionsMap, namespace) {
   const flattenedActionsMap = flattenActions(actionsMap, namespace);
-  const flattenedActionCreators = Object.keys(flattenedActionsMap).reduce((actionCreatorsMap, type) => {
-    const actionsMapValue = flattenedActionsMap[type];
-    invariant(
-      isValidActionsMapValue(actionsMapValue),
-      'Expected function, undefined, or array with payload and meta ' +
-      `functions for ${type}`
-    );
-    const actionCreator = isArray(actionsMapValue)
-      ? createAction(type, ...actionsMapValue)
-      : createAction(type, actionsMapValue);
-    return { ...actionCreatorsMap, [type]: actionCreator };
-  }, {});
+  const flattenedActionCreators = Object
+    .keys(flattenedActionsMap)
+    .reduce((actionCreatorsMap, type) => {
+      const actionsMapValue = flattenedActionsMap[type];
+      invariant(
+        isValidActionsMapValue(actionsMapValue),
+        'Expected function, undefined, or array with payload and meta ' +
+        `functions for ${type}`
+      );
+      const actionCreator = isArray(actionsMapValue)
+        ? createAction(type, ...actionsMapValue)
+        : createAction(type, actionsMapValue);
+      return { ...actionCreatorsMap, [type]: actionCreator };
+    }, {});
   return unflattenActions(flattenedActionCreators, namespace);
 }
 

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -16,12 +16,13 @@ import {
 } from './namespaceActions';
 
 export default function createActions(actionMap, ...identityActions) {
-  function getFullOptions(options = {}) {
-    return defaults(options, { namespace: defaultNamespace });
+  function getFullOptions() {
+    const partialOptions = isPlainObject(last(identityActions))
+      ? identityActions.pop()
+      : {};
+    return defaults(partialOptions, { namespace: defaultNamespace });
   }
-  const { namespace } = getFullOptions(
-    isPlainObject(last(identityActions)) ? identityActions.pop() : {}
-  );
+  const { namespace } = getFullOptions();
   invariant(
     identityActions.every(isString) &&
     (isString(actionMap) || isPlainObject(actionMap)),

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -21,7 +21,7 @@ export default function createActions(actionsMap, ...identityActions) {
     return fromIdentityActions([actionsMap, ...identityActions]);
   }
   return unflattenActions({
-    ...fromActionsMap(flattenActions(actionsMap)),
+    ...fromActionsMap(actionsMap),
     ...fromIdentityActions(identityActions)
   });
 }
@@ -43,18 +43,18 @@ function isValidActionsMapValue(actionsMapValue) {
 }
 
 function fromActionsMap(actionsMap) {
-  const actionTypes = Object.keys(actionsMap);
-  actionTypes.forEach(type => invariant(
+  Object.keys(actionsMap).forEach(type => invariant(
     isValidActionsMapValue(actionsMap[type]),
     'Expected function, undefined, or array with payload and meta ' +
     `functions for ${type}`
   ));
-  return actionTypes.reduce((actionCreatorsMap, type) => {
-    const actionsMapValue = actionsMap[type];
+  const flattenedActionsMap = flattenActions(actionsMap);
+  return Object.keys(flattenedActionsMap).reduce((actionCreatorsMap, namespacedType) => {
+    const actionsMapValue = flattenedActionsMap[namespacedType];
     const actionCreator = isArray(actionsMapValue)
-      ? createAction(type, ...actionsMapValue)
-      : createAction(type, actionsMapValue);
-    return { ...actionCreatorsMap, [camelCase(type)]: actionCreator };
+      ? createAction(namespacedType, ...actionsMapValue)
+      : createAction(namespacedType, actionsMapValue);
+    return { ...actionCreatorsMap, [camelCase(namespacedType)]: actionCreator };
   }, {});
 }
 

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -47,7 +47,7 @@ function isValidActionMapValue(actionMapValue) {
   return false;
 }
 
-function toActionCreators(actionMap) {
+function actionMapToActionCreators(actionMap) {
   return arrayToObject(Object.keys(actionMap), (partialActionCreators, type) => {
     const actionMapValue = actionMap[type];
     invariant(
@@ -70,7 +70,7 @@ function actionCreatorsFromIdentityActions(identityActions) {
       [type]: identity
     })
   );
-  const actionCreators = toActionCreators(actionMap);
+  const actionCreators = actionMapToActionCreators(actionMap);
   return arrayToObject(
     Object.keys(actionCreators),
     (partialActionCreators, type) => ({
@@ -82,6 +82,6 @@ function actionCreatorsFromIdentityActions(identityActions) {
 
 function actionCreatorsFromActionMap(actionMap, namespace) {
   const flatActionMap = flattenActionMap(actionMap, namespace);
-  const flatActionCreators = toActionCreators(flatActionMap);
+  const flatActionCreators = actionMapToActionCreators(flatActionMap);
   return unflattenActionCreators(flatActionCreators, namespace);
 }

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -42,7 +42,6 @@ function isValidActionMapValue(actionMapValue) {
     return true;
   } else if (isArray(actionMapValue)) {
     const [payload = identity, meta] = actionMapValue;
-
     return isFunction(payload) && isFunction(meta);
   }
   return false;
@@ -64,15 +63,21 @@ function toActionCreators(actionMap) {
 }
 
 function actionCreatorsFromIdentityActions(identityActions) {
-  const actionMap = arrayToObject(identityActions, (partialActionMap, type) => ({
-    ...partialActionMap,
-    [type]: identity
-  }));
+  const actionMap = arrayToObject(
+    identityActions,
+    (partialActionMap, type) => ({
+      ...partialActionMap,
+      [type]: identity
+    })
+  );
   const actionCreators = toActionCreators(actionMap);
-  return arrayToObject(Object.keys(actionCreators), (partialActionCreators, type) => ({
-    ...partialActionCreators,
-    [camelCase(type)]: actionCreators[type]
-  }));
+  return arrayToObject(
+    Object.keys(actionCreators),
+    (partialActionCreators, type) => ({
+      ...partialActionCreators,
+      [camelCase(type)]: actionCreators[type]
+    })
+  );
 }
 
 function actionCreatorsFromActionMap(actionMap, namespace) {

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -31,19 +31,13 @@ export default function createActions(actionMap, ...identityActions) {
   if (isString(actionMap)) {
     return actionCreatorsFromIdentityActions([actionMap, ...identityActions]);
   }
-  const flatActionsMap = flattenActionMap(actionMap, namespace);
-  const flatActionCreators = toActionCreators(flatActionsMap);
-  const actionCreatorsFromActionsMap = unflattenActionCreators(
-    flatActionCreators,
-    namespace
-  );
   return {
-    ...actionCreatorsFromActionsMap,
+    ...actionCreatorsFromActionMap(actionMap, namespace),
     ...actionCreatorsFromIdentityActions(identityActions)
   };
 }
 
-function isValidActionsMapValue(actionMapValue) {
+function isValidActionMapValue(actionMapValue) {
   if (isFunction(actionMapValue)) {
     return true;
   } else if (isArray(actionMapValue)) {
@@ -58,7 +52,7 @@ function toActionCreators(actionMap) {
   return arrayToObject(Object.keys(actionMap), (partialActionCreators, type) => {
     const actionMapValue = actionMap[type];
     invariant(
-      isValidActionsMapValue(actionMapValue),
+      isValidActionMapValue(actionMapValue),
       'Expected function, undefined, or array with payload and meta ' +
       `functions for ${type}`
     );
@@ -70,8 +64,8 @@ function toActionCreators(actionMap) {
 }
 
 function actionCreatorsFromIdentityActions(identityActions) {
-  const actionMap = arrayToObject(identityActions, (partialActionsMap, type) => ({
-    ...partialActionsMap,
+  const actionMap = arrayToObject(identityActions, (partialActionMap, type) => ({
+    ...partialActionMap,
     [type]: identity
   }));
   const actionCreators = toActionCreators(actionMap);
@@ -79,4 +73,10 @@ function actionCreatorsFromIdentityActions(identityActions) {
     ...partialActionCreators,
     [camelCase(type)]: actionCreators[type]
   }));
+}
+
+function actionCreatorsFromActionMap(actionMap, namespace) {
+  const flatActionMap = flattenActionMap(actionMap, namespace);
+  const flatActionCreators = toActionCreators(flatActionMap);
+  return unflattenActionCreators(flatActionCreators, namespace);
 }

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -19,17 +19,17 @@ export default function createActions(actionsMap, ...identityActions) {
     'Expected optional object followed by string action types'
   );
   if (isString(actionsMap)) {
-    return fromIdentityActions([actionsMap, ...identityActions]);
+    return actionCreatorsFromIdentityActions([actionsMap, ...identityActions]);
   }
   return {
     ...unflattenActions(
-      fromActionsMap(
+      attachActionCreators(
         flattenActions(actionsMap, namespace),
         namespace
       ),
       namespace
     ),
-    ...fromIdentityActions(identityActions)
+    ...actionCreatorsFromIdentityActions(identityActions)
   };
 }
 
@@ -44,7 +44,7 @@ function isValidActionsMapValue(actionsMapValue) {
   return false;
 }
 
-function fromActionsMap(actionsMap) {
+function attachActionCreators(actionsMap) {
   return Object.keys(actionsMap).reduce((actionCreatorsMap, type) => {
     const actionsMapValue = actionsMap[type];
     invariant(
@@ -59,8 +59,8 @@ function fromActionsMap(actionsMap) {
   }, {});
 }
 
-function fromIdentityActions(identityActions) {
-  const actionCreators = fromActionsMap(identityActions.reduce((actionsMap, actionType) => ({
+function actionCreatorsFromIdentityActions(identityActions) {
+  const actionCreators = attachActionCreators(identityActions.reduce((actionsMap, actionType) => ({
     ...actionsMap,
     [actionType]: identity
   })

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -6,6 +6,7 @@ import isString from 'lodash/isString';
 import isFunction from 'lodash/isFunction';
 import createAction from './createAction';
 import invariant from 'invariant';
+import { flattenActions, unflattenActions } from './namespaceActions';
 
 export default function createActions(actionsMap, ...identityActions) {
   invariant(
@@ -16,7 +17,10 @@ export default function createActions(actionsMap, ...identityActions) {
   if (isString(actionsMap)) {
     return fromIdentityActions([actionsMap, ...identityActions]);
   }
-  return { ...fromActionsMap(actionsMap), ...fromIdentityActions(identityActions) };
+  return unflattenActions({
+    ...fromActionsMap(flattenActions(actionsMap)),
+    ...fromIdentityActions(identityActions)
+  });
 }
 
 function isValidActionsMapValue(actionsMapValue) {

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -4,6 +4,7 @@ import isPlainObject from 'lodash/isPlainObject';
 import isArray from 'lodash/isArray';
 import last from 'lodash/last';
 import isString from 'lodash/isString';
+import defaults from 'lodash/defaults';
 import isFunction from 'lodash/isFunction';
 import createAction from './createAction';
 import invariant from 'invariant';
@@ -14,10 +15,15 @@ import {
   unflattenActionCreators
 } from './namespaceActions';
 
+const defaultOptions = { namespace: defaultNamespace };
+
 export default function createActions(actionsMap, ...identityActions) {
-  const namespace = isPlainObject(last(identityActions))
-    ? identityActions.pop().namespace
-    : defaultNamespace;
+  const { namespace } = defaults(
+    isPlainObject(last(identityActions))
+      ? identityActions.pop()
+      : {},
+    defaultOptions
+  );
   invariant(
     identityActions.every(isString) &&
     (isString(actionsMap) || isPlainObject(actionsMap)),

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -15,14 +15,13 @@ import {
   unflattenActionCreators
 } from './namespaceActions';
 
-const defaultOptions = { namespace: defaultNamespace };
+function getFullOptions(options = {}) {
+  return defaults(options, { namespace: defaultNamespace });
+}
 
 export default function createActions(actionsMap, ...identityActions) {
-  const { namespace } = defaults(
-    isPlainObject(last(identityActions))
-      ? identityActions.pop()
-      : {},
-    defaultOptions
+  const { namespace } = getFullOptions(
+    isPlainObject(last(identityActions)) ? identityActions.pop() : {}
   );
   invariant(
     identityActions.every(isString) &&

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -23,10 +23,7 @@ export default function createActions(actionsMap, ...identityActions) {
   }
   return {
     ...unflattenActions(
-      attachActionCreators(
-        flattenActions(actionsMap, namespace),
-        namespace
-      ),
+      attachActionCreators(flattenActions(actionsMap, namespace)),
       namespace
     ),
     ...actionCreatorsFromIdentityActions(identityActions)

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -15,11 +15,10 @@ import {
   unflattenActionCreators
 } from './namespaceActions';
 
-function getFullOptions(options = {}) {
-  return defaults(options, { namespace: defaultNamespace });
-}
-
 export default function createActions(actionMap, ...identityActions) {
+  function getFullOptions(options = {}) {
+    return defaults(options, { namespace: defaultNamespace });
+  }
   const { namespace } = getFullOptions(
     isPlainObject(last(identityActions)) ? identityActions.pop() : {}
   );
@@ -37,17 +36,23 @@ export default function createActions(actionMap, ...identityActions) {
   };
 }
 
-function isValidActionMapValue(actionMapValue) {
-  if (isFunction(actionMapValue)) {
-    return true;
-  } else if (isArray(actionMapValue)) {
-    const [payload = identity, meta] = actionMapValue;
-    return isFunction(payload) && isFunction(meta);
-  }
-  return false;
+function actionCreatorsFromActionMap(actionMap, namespace) {
+  const flatActionMap = flattenActionMap(actionMap, namespace);
+  const flatActionCreators = actionMapToActionCreators(flatActionMap);
+  return unflattenActionCreators(flatActionCreators, namespace);
 }
 
 function actionMapToActionCreators(actionMap) {
+  function isValidActionMapValue(actionMapValue) {
+    if (isFunction(actionMapValue)) {
+      return true;
+    } else if (isArray(actionMapValue)) {
+      const [payload = identity, meta] = actionMapValue;
+      return isFunction(payload) && isFunction(meta);
+    }
+    return false;
+  }
+
   return arrayToObject(Object.keys(actionMap), (partialActionCreators, type) => {
     const actionMapValue = actionMap[type];
     invariant(
@@ -78,10 +83,4 @@ function actionCreatorsFromIdentityActions(identityActions) {
       [camelCase(type)]: actionCreators[type]
     })
   );
-}
-
-function actionCreatorsFromActionMap(actionMap, namespace) {
-  const flatActionMap = flattenActionMap(actionMap, namespace);
-  const flatActionCreators = actionMapToActionCreators(flatActionMap);
-  return unflattenActionCreators(flatActionCreators, namespace);
 }

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -71,10 +71,7 @@ function actionMapToActionCreators(actionMap) {
 function actionCreatorsFromIdentityActions(identityActions) {
   const actionMap = arrayToObject(
     identityActions,
-    (partialActionMap, type) => ({
-      ...partialActionMap,
-      [type]: identity
-    })
+    (partialActionMap, type) => ({ ...partialActionMap, [type]: identity })
   );
   const actionCreators = actionMapToActionCreators(actionMap);
   return arrayToObject(

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -7,11 +7,11 @@ import includes from 'lodash/includes';
 import invariant from 'invariant';
 import { ACTION_TYPE_DELIMITER } from './combineActions';
 
-export default function handleAction(actionType, reducer = identity, defaultState) {
-  const actionTypes = actionType.toString().split(ACTION_TYPE_DELIMITER);
+export default function handleAction(type, reducer = identity, defaultState) {
+  const types = type.toString().split(ACTION_TYPE_DELIMITER);
   invariant(
     !isUndefined(defaultState),
-    `defaultState for reducer handling ${actionTypes.join(', ')} should be defined`
+    `defaultState for reducer handling ${types.join(', ')} should be defined`
   );
   invariant(
     isFunction(reducer) || isPlainObject(reducer),
@@ -23,8 +23,8 @@ export default function handleAction(actionType, reducer = identity, defaultStat
     : [reducer.next, reducer.throw].map(aReducer => (isNil(aReducer) ? identity : aReducer));
 
   return (state = defaultState, action) => {
-    const { type } = action;
-    if (!type || !includes(actionTypes, type.toString())) {
+    const { type: actionType } = action;
+    if (!actionType || !includes(types, actionType.toString())) {
       return state;
     }
 

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -28,7 +28,9 @@ function unflattenActions(actionCreatorsMap, namespacer = defaultNamespacer) {
   ) {
     const nextActionType = actionTypePath.shift();
     if (actionTypePath.length) {
-      unflattenedActions[nextActionType] = {};
+      unflattenedActions[nextActionType] = unflattenedActions[nextActionType]
+        ? unflattenedActions[nextActionType]
+        : {};
       unflatten(unflattenedActions[nextActionType], flattenedActionType, actionTypePath);
     } else {
       unflattenedActions[nextActionType] = actionCreatorsMap[flattenedActionType];

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -1,6 +1,7 @@
 import isFunction from 'lodash/isFunction';
 import camelCase from './camelCase';
 import isArray from 'lodash/isArray';
+import isPlainObject from 'lodash/isPlainObject';
 
 const defaultNamespace = '/';
 
@@ -16,7 +17,7 @@ function flattenActions(
   Object.getOwnPropertyNames(actionsMap).forEach(actionType => {
     const nextActionType = getNextActionType(actionType);
     const actionsMapValue = actionsMap[actionType];
-    if (isFunction(actionsMapValue) || isArray(actionsMapValue)) {
+    if (!isPlainObject(actionsMapValue)) {
       flattenedActions[nextActionType] = actionsMap[actionType];
     } else {
       flattenActions(actionsMap[actionType], namespace, flattenedActions, nextActionType);

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -1,6 +1,4 @@
-import isFunction from 'lodash/isFunction';
 import camelCase from './camelCase';
-import isArray from 'lodash/isArray';
 import isPlainObject from 'lodash/isPlainObject';
 
 const defaultNamespace = '/';

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -3,7 +3,7 @@ import isPlainObject from 'lodash/isPlainObject';
 
 const defaultNamespace = '/';
 
-function flattenActions(
+function flattenActionsMap(
   actionsMap,
   namespace = defaultNamespace,
   flattenedActions = {},
@@ -20,13 +20,13 @@ function flattenActions(
     if (!isPlainObject(actionsMapValue)) {
       flattenedActions[nextActionType] = actionsMap[actionType];
     } else {
-      flattenActions(actionsMap[actionType], namespace, flattenedActions, nextActionType);
+      flattenActionsMap(actionsMap[actionType], namespace, flattenedActions, nextActionType);
     }
   });
   return flattenedActions;
 }
 
-function unflattenActions(actionCreatorsMap, namespace = defaultNamespace) {
+function unflattenActionCreators(actionCreatorsMap, namespace = defaultNamespace) {
   function unflatten(
     unflattenedActions = {},
     flattenedActionType,
@@ -50,4 +50,4 @@ function unflattenActions(actionCreatorsMap, namespace = defaultNamespace) {
   return unflattenedActions;
 }
 
-export { flattenActions, unflattenActions };
+export { flattenActionsMap, unflattenActionCreators };

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -1,15 +1,17 @@
 import isFunction from 'lodash/isFunction';
+import camelCase from './camelCase';
 import isArray from 'lodash/isArray';
-const defaultNamespacer = '/';
+
+const defaultNamespace = '/';
 
 function flattenActions(
   actionsMap,
-  namespacer = defaultNamespacer,
+  namespace = defaultNamespace,
   flattenedActions = {},
   flattenedActionType = ''
 ) {
   function getNextActionType(actionType) {
-    return flattenedActionType ? `${flattenedActionType}${namespacer}${actionType}` : actionType;
+    return flattenedActionType ? `${flattenedActionType}${namespace}${actionType}` : actionType;
   }
   Object.getOwnPropertyNames(actionsMap).forEach(actionType => {
     const nextActionType = getNextActionType(actionType);
@@ -17,19 +19,19 @@ function flattenActions(
     if (isFunction(actionsMapValue) || isArray(actionsMapValue)) {
       flattenedActions[nextActionType] = actionsMap[actionType];
     } else {
-      flattenActions(actionsMap[actionType], namespacer, flattenedActions, nextActionType);
+      flattenActions(actionsMap[actionType], namespace, flattenedActions, nextActionType);
     }
   });
   return flattenedActions;
 }
 
-function unflattenActions(actionCreatorsMap, namespacer = defaultNamespacer) {
+function unflattenActions(actionCreatorsMap, namespace = defaultNamespace) {
   function unflatten(
     unflattenedActions = {},
     flattenedActionType,
     actionTypePath,
   ) {
-    const nextActionType = actionTypePath.shift();
+    const nextActionType = camelCase(actionTypePath.shift());
     if (actionTypePath.length) {
       if (!unflattenedActions[nextActionType]) {
         unflattenedActions[nextActionType] = {};
@@ -42,7 +44,7 @@ function unflattenActions(actionCreatorsMap, namespacer = defaultNamespacer) {
   const unflattenedActions = {};
   Object
     .getOwnPropertyNames(actionCreatorsMap)
-    .forEach(actionType => unflatten(unflattenedActions, actionType, actionType.split(namespacer)));
+    .forEach(actionType => unflatten(unflattenedActions, actionType, actionType.split(namespace)));
   return unflattenedActions;
 }
 

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -3,8 +3,8 @@ import isPlainObject from 'lodash/isPlainObject';
 
 const defaultNamespace = '/';
 
-function flattenActionsMap(
-  actionsMap,
+function flattenActionMap(
+  actionMap,
   namespace = defaultNamespace,
   flattenedActions = {},
   flattenedActionType = ''
@@ -13,14 +13,14 @@ function flattenActionsMap(
     return flattenedActionType ? `${flattenedActionType}${namespace}${actionType}` : actionType;
   }
 
-  Object.getOwnPropertyNames(actionsMap).forEach(actionType => {
+  Object.getOwnPropertyNames(actionMap).forEach(actionType => {
     const nextActionType = getNextActionType(actionType);
-    const actionsMapValue = actionsMap[actionType];
+    const actionMapValue = actionMap[actionType];
 
-    if (!isPlainObject(actionsMapValue)) {
-      flattenedActions[nextActionType] = actionsMap[actionType];
+    if (!isPlainObject(actionMapValue)) {
+      flattenedActions[nextActionType] = actionMap[actionType];
     } else {
-      flattenActionsMap(actionsMap[actionType], namespace, flattenedActions, nextActionType);
+      flattenActionMap(actionMap[actionType], namespace, flattenedActions, nextActionType);
     }
   });
   return flattenedActions;
@@ -50,4 +50,4 @@ function unflattenActionCreators(actionCreatorsMap, namespace = defaultNamespace
   return unflattenedActions;
 }
 
-export { flattenActionsMap, unflattenActionCreators };
+export { flattenActionMap, unflattenActionCreators };

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -28,9 +28,9 @@ function unflattenActions(actionCreatorsMap, namespacer = defaultNamespacer) {
   ) {
     const nextActionType = actionTypePath.shift();
     if (actionTypePath.length) {
-      unflattenedActions[nextActionType] = unflattenedActions[nextActionType]
-        ? unflattenedActions[nextActionType]
-        : {};
+      if (!unflattenedActions[nextActionType]) {
+        unflattenedActions[nextActionType] = {};
+      }
       unflatten(unflattenedActions[nextActionType], flattenedActionType, actionTypePath);
     } else {
       unflattenedActions[nextActionType] = actionCreatorsMap[flattenedActionType];

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -1,3 +1,5 @@
+import isFunction from 'lodash/isFunction';
+import isArray from 'lodash/isArray';
 const defaultNamespacer = '/';
 
 function flattenActions(
@@ -11,7 +13,8 @@ function flattenActions(
   }
   Object.getOwnPropertyNames(actionsMap).forEach(actionType => {
     const nextActionType = getNextActionType(actionType);
-    if (typeof actionsMap[actionType] === 'function') {
+    const actionsMapValue = actionsMap[actionType];
+    if (isFunction(actionsMapValue) || isArray(actionsMapValue)) {
       flattenedActions[nextActionType] = actionsMap[actionType];
     } else {
       flattenActions(actionsMap[actionType], namespacer, flattenedActions, nextActionType);

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -12,9 +12,11 @@ function flattenActions(
   function getNextActionType(actionType) {
     return flattenedActionType ? `${flattenedActionType}${namespace}${actionType}` : actionType;
   }
+
   Object.getOwnPropertyNames(actionsMap).forEach(actionType => {
     const nextActionType = getNextActionType(actionType);
     const actionsMapValue = actionsMap[actionType];
+
     if (!isPlainObject(actionsMapValue)) {
       flattenedActions[nextActionType] = actionsMap[actionType];
     } else {
@@ -40,6 +42,7 @@ function unflattenActions(actionCreatorsMap, namespace = defaultNamespace) {
       unflattenedActions[nextActionType] = actionCreatorsMap[flattenedActionType];
     }
   }
+
   const unflattenedActions = {};
   Object
     .getOwnPropertyNames(actionCreatorsMap)

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -1,0 +1,44 @@
+const defaultNamespacer = '/';
+
+function flattenActions(
+  actionsMap,
+  namespacer = defaultNamespacer,
+  flattenedActions = {},
+  flattenedActionType = ''
+) {
+  function getNextActionType(actionType) {
+    return flattenedActionType ? `${flattenedActionType}${namespacer}${actionType}` : actionType;
+  }
+  Object.getOwnPropertyNames(actionsMap).forEach(actionType => {
+    const nextActionType = getNextActionType(actionType);
+    if (typeof actionsMap[actionType] === 'function') {
+      flattenedActions[nextActionType] = actionsMap[actionType];
+    } else {
+      flattenActions(actionsMap[actionType], namespacer, flattenedActions, nextActionType);
+    }
+  });
+  return flattenedActions;
+}
+
+function unflattenActions(actionCreatorsMap, namespacer = defaultNamespacer) {
+  function unflatten(
+    unflattenedActions = {},
+    flattenedActionType,
+    actionTypePath,
+  ) {
+    const nextActionType = actionTypePath.shift();
+    if (actionTypePath.length) {
+      unflattenedActions[nextActionType] = {};
+      unflatten(unflattenedActions[nextActionType], flattenedActionType, actionTypePath);
+    } else {
+      unflattenedActions[nextActionType] = actionCreatorsMap[flattenedActionType];
+    }
+  }
+  const unflattenedActions = {};
+  Object
+    .getOwnPropertyNames(actionCreatorsMap)
+    .forEach(actionType => unflatten(unflattenedActions, actionType, actionType.split(namespacer)));
+  return unflattenedActions;
+}
+
+export { flattenActions, unflattenActions };

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -32,7 +32,7 @@ function unflattenActionCreators(flatActionCreators, namespace = defaultNamespac
   function unflatten(
     flatActionType,
     partialNestedActionCreators = {},
-    partialFlatActionTypePath,
+    partialFlatActionTypePath = [],
   ) {
     const nextNamespace = camelCase(partialFlatActionTypePath.shift());
     if (partialFlatActionTypePath.length) {


### PR DESCRIPTION
This uses a pretty standard recursive algorithm to allow for namespacing action creators and action types. Closes #159, #195.

CC: @renato, @tugorez

I originally didn't want this code to be in this library, but several people have asked for it, and I don't think it's unreasonable to include it.