### PR TITLE
Utilize lodash-es in es builds.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,12 @@
   "presets": [
     "./build/preset-es2015",
     "stage-0"
-  ]
+  ],
+  "env": {
+    "es": {
+      "plugins": [
+        "./build/use-lodash-es"
+      ]
+    }
+  }
 }

--- a/build/use-lodash-es.js
+++ b/build/use-lodash-es.js
@@ -1,0 +1,10 @@
+module.exports = function useLodashEs() {
+  return {
+    visitor: {
+      ImportDeclaration(path) {
+        const source = path.node.source;
+        source.value = source.value.replace(/^lodash($|\/)/, 'lodash-es$1');
+      }
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "invariant": "^2.2.1",
     "lodash": "^4.13.1",
+    "lodash-es": "^4.17.4",
     "reduce-reducers": "^0.1.0"
   }
 }


### PR DESCRIPTION
This pattern exists in a few libraries that often coexist with redux actions:

https://github.com/reactjs/redux/blob/master/build/use-lodash-es.js
https://github.com/rt2zz/redux-persist/blob/master/tools/use-lodash-es.js

Without this patch, my bundle contains lodash-es and lodash modules. With the patch included, I was able to shave off a few gzipped KBs by sharing the already required/included lodash-es modules.