### PR TITLE
createAction does more pre-processing

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -23,7 +23,11 @@ export default function createAction(type, payloadCreator = identity, metaCreato
 
   const actionCreator = (...args) => {
     const payload = finalPayloadCreator(...args);
-    const action = { type, error: payload instanceof Error };
+    const action = { type };
+
+    if (payload instanceof Error) {
+      action.error = true;
+    }
 
     if (payload !== undefined) {
       action.payload = payload;

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -9,18 +9,22 @@ export default function createAction(type, payloadCreator = identity, metaCreato
     'Expected payloadCreator to be a function, undefined or null'
   );
 
+  const wrappedPayloadCreator = (head, ...args) => (head instanceof Error 
+    ? head 
+    : payloadCreator(head, ...args));
+
   const finalPayloadCreator = isNull(payloadCreator) || payloadCreator === identity
     ? identity
-    : ((head, ...args) => head instanceof Error ? head : payloadCreator(head, ...args));
-  
+    : wrappedPayloadCreator;
+
   const hasMeta = isFunction(metaCreator);
-  
+
   const typeString = type.toString();
 
   const actionCreator = (...args) => {
     const payload = finalPayloadCreator(...args);
-    const action = {type, error: payload instanceof Error};
-    
+    const action = { type, error: payload instanceof Error };
+
     if (payload !== undefined) {
       action.payload = payload;
     }

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -9,8 +9,8 @@ export default function createAction(type, payloadCreator = identity, metaCreato
     'Expected payloadCreator to be a function, undefined or null'
   );
 
-  const wrappedPayloadCreator = (head, ...args) => (head instanceof Error 
-    ? head 
+  const wrappedPayloadCreator = (head, ...args) => (head instanceof Error
+    ? head
     : payloadCreator(head, ...args));
 
   const finalPayloadCreator = isNull(payloadCreator) || payloadCreator === identity

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -28,7 +28,7 @@ export default function createAction(type, payloadCreator = identity, metaCreato
     if (payload !== undefined) {
       action.payload = payload;
     }
-    
+
     if (hasMeta) {
       action.meta = metaCreator(...args);
     }

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -7,18 +7,19 @@ export default function createAction(type, payloadCreator = identity, metaCreato
   invariant(
     isFunction(payloadCreator) || isNull(payloadCreator),
     'Expected payloadCreator to be a function, undefined or null'
-  );
+  )
 
-  const finalPayloadCreator = payloadCreator === null || payloadCreator === identity
+  const finalPayloadCreator = isNull(payloadCreator) || payloadCreator === identity
     ? identity
-    : (head, ...args) => head instanceof Error ?
-        head : payloadCreator(head, ...args);
+    : ((head, ...args) => head instanceof Error ? head : payloadCreator(head, ...args));
   
   const hasMeta = isFunction(metaCreator);
+  
+  const typeString = type.toString();
 
   const actionCreator = (...args) => {
     const payload = finalPayloadCreator(...args);
-    const action = { type, error: payload instanceof Error };
+    const action = {type, error: payload instanceof Error};
     
     if (payload !== undefined) {
       action.payload = payload;
@@ -31,8 +32,7 @@ export default function createAction(type, payloadCreator = identity, metaCreato
     return action;
   };
 
-  const typeStr = type.toString();
-  actionCreator.toString = () => typeStr;
+  actionCreator.toString = () => typeString;
 
   return actionCreator;
 }

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -7,7 +7,7 @@ export default function createAction(type, payloadCreator = identity, metaCreato
   invariant(
     isFunction(payloadCreator) || isNull(payloadCreator),
     'Expected payloadCreator to be a function, undefined or null'
-  )
+  );
 
   const finalPayloadCreator = isNull(payloadCreator) || payloadCreator === identity
     ? identity

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -9,16 +9,12 @@ export default function createAction(type, payloadCreator = identity, metaCreato
     'Expected payloadCreator to be a function, undefined or null'
   );
 
-  const wrappedPayloadCreator = (head, ...args) => (head instanceof Error
-    ? head
-    : payloadCreator(head, ...args));
-
   const finalPayloadCreator = isNull(payloadCreator) || payloadCreator === identity
     ? identity
-    : wrappedPayloadCreator;
+    : (head, ...args) => (head instanceof Error
+      ? head : payloadCreator(head, ...args));
 
   const hasMeta = isFunction(metaCreator);
-
   const typeString = type.toString();
 
   const actionCreator = (...args) => {


### PR DESCRIPTION
Slightly simplified createAction, and made it do more processing ahead of time that doesn't have to be done every time an action is emitted