### PR TITLE
Make default payload creator ignores synthetic events.

### DIFF
--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -23,6 +23,18 @@ describe('createAction()', () => {
       });
     });
 
+    it('returns a null payload by default when passed a synthetic event', () => {
+      const actionCreator = createAction(type);
+      const syntheticEvent = {
+        persist: () => 'foo'
+      };
+      const action = actionCreator(syntheticEvent);
+      expect(action).to.deep.equal({
+        type,
+        payload: null
+      });
+    });
+
     it('should throw an error if payloadCreator is not a function, undefined, null', () => {
       const wrongTypePayloadCreators = [1, false, 'string', {}, []];
 

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -1,16 +1,22 @@
-import identity from 'lodash/identity';
 import isFunction from 'lodash/isFunction';
 import isNull from 'lodash/isNull';
 import invariant from 'invariant';
 
-export default function createAction(type, payloadCreator = identity, metaCreator) {
+const defaultPayloadCreator = (arg) => {
+  if (arg && typeof arg.persist === 'function') {
+    return null;
+  }
+  return arg;
+};
+
+export default function createAction(type, payloadCreator = defaultPayloadCreator, metaCreator) {
   invariant(
     isFunction(payloadCreator) || isNull(payloadCreator),
     'Expected payloadCreator to be a function, undefined or null'
   );
 
-  const finalPayloadCreator = isNull(payloadCreator) || payloadCreator === identity
-    ? identity
+  const finalPayloadCreator = isNull(payloadCreator) || payloadCreator === defaultPayloadCreator
+    ? defaultPayloadCreator
     : (head, ...args) => (head instanceof Error
       ? head : payloadCreator(head, ...args));
 


### PR DESCRIPTION
When combining this library with `react-redux` I noticed a whole bunch of errors in my console when firing lots of events:

![image](https://cloud.githubusercontent.com/assets/174864/26371797/d321abfe-3fc9-11e7-92c3-c1b38794cdd9.png)

The component causing the errors is written as such:

```jsx
const Counter = ({ increment, decrement, counter }) => (
  <div>
    <h1>Counter: {counter}</h1>
    <button onClick={increment}>+1</button>
    <button onClick={decrement}>-1</button>
  </div>
);
```

One solution is to rewrite the component so the synthetic event from React is not passed to the action creator:

```jsx
const Counter = ({ increment, decrement, counter }) => (
  <div>
    <h1>Counter: {counter}</h1>
    <button onClick={() => increment()}>+1</button>
    <button onClick={() => decrement()}>-1</button>
  </div>
);
```

This has the potential to violate some [linting rules](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md). That's where using something like `withHandlers` from `recompose` comes in:

```jsx
const Counter = ({ increment, decrement, counter }) => (
  <div>
    <h1>Counter: {counter}</h1>
    <button onClick={increment}>+1</button>
    <button onClick={decrement}>-1</button>
  </div>
);

// ...

export default compose(
  pure,
  withHandlers({
    increment: props => () => props.increment(),
    decrement: props => () => props.decrement(),
  }),
)(Counter);
```

But this feels like overkill for what the component is and what it does. This change simply makes the default payload creator return a `null` payload if it is passed a synthetic event, thus enabling the very first example to be valid.

Thoughts?