### PR TITLE
Allow nested reducer map in handleActions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equa
   meta: { username: 'yangmillstheory', message: 'Hello World' }
 });
 ```
-When using this form, you can pass an object with key `namespace` as the last positional argument, instead of the default `/`.
+When using this form, you can pass an object with key `namespace` as the last positional argument (the default is `/`).
 
 ### `handleAction(type, reducer | reducerMap = Identity, defaultState)`
 
@@ -199,7 +199,7 @@ If the reducer argument (`reducer | reducerMap`) is `undefined`, then the identi
 
 The third parameter `defaultState` is required, and is used when `undefined` is passed to the reducer.
 
-### `handleActions(reducerMap, defaultState)`
+### `handleActions(reducerMap, defaultState, )`
 
 ```js
 import { handleActions } from 'redux-actions';
@@ -207,7 +207,7 @@ import { handleActions } from 'redux-actions';
 
 Creates multiple reducers using `handleAction()` and combines them into a single reducer that handles multiple actions. Accepts a map where the keys are passed as the first parameter to `handleAction()` (the action type), and the values are passed as the second parameter (either a reducer or reducer map). The map must not be empty.
 
-If `reducerMap` has a recursive structure, its leaves are used as reducers, and the action type for each leaf is the path to that leaf. If a node's only children are `next()` and `throw()`, the node will be treated as a reducer.
+If `reducerMap` has a recursive structure, its leaves are used as reducers, and the action type for each leaf is the path to that leaf. If a node's only children are `next()` and `throw()`, the node will be treated as a reducer. If the leaf is `undefined` or `null`, the identity function is used as the reducer. Otherwise, the leaf should be the reducer function. When using this form, you can pass an object with key `namespace` as the last positional argument (the default is `/`).
 
 The second parameter `defaultState` is required, and is used when `undefined` is passed to the reducer.
 

--- a/README.md
+++ b/README.md
@@ -207,8 +207,7 @@ import { handleActions } from 'redux-actions';
 
 Creates multiple reducers using `handleAction()` and combines them into a single reducer that handles multiple actions. Accepts a map where the keys are passed as the first parameter to `handleAction()` (the action type), and the values are passed as the second parameter (either a reducer or reducer map). The map must not be empty.
 
-If `reducerMap` has a recursive structure, its leaves are used as reducers, and the action type for each leaf is the combined path to that leaf.
-If a nodes only children are `next()` and `throw()`, the node will be treated as a reducer leaf.
+If `reducerMap` has a recursive structure, its leaves are used as reducers, and the action type for each leaf is the path to that leaf. If a node's only children are `next()` and `throw()`, the node will be treated as a reducer.
 
 The second parameter `defaultState` is required, and is used when `undefined` is passed to the reducer.
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ import { handleActions } from 'redux-actions';
 
 Creates multiple reducers using `handleAction()` and combines them into a single reducer that handles multiple actions. Accepts a map where the keys are passed as the first parameter to `handleAction()` (the action type), and the values are passed as the second parameter (either a reducer or reducer map). The map must not be empty.
 
+If `reducerMap` has a recursive structure, its leaves are used as reducers, and the action type for each leaf is the combined path to that leaf.
+If a nodes only children are `next()` and `throw()`, the node will be treated as a reducer leaf.
+
 The second parameter `defaultState` is required, and is used when `undefined` is passed to the reducer.
 
 (Internally, `handleActions()` works by applying multiple reducers in sequence using [reduce-reducers](https://github.com/acdlite/reduce-reducers).)

--- a/src/__tests__/handleActions-test.js
+++ b/src/__tests__/handleActions-test.js
@@ -327,6 +327,74 @@ describe('handleActions', () => {
     });
   });
 
+  it('should work with nested reducerMap and namespace', () => {
+    const {
+      app: {
+        counter: {
+          increment,
+          decrement
+        },
+        notify
+      }
+    } = createActions({
+      APP: {
+        COUNTER: {
+          INCREMENT: [
+            amount => ({ amount }),
+            amount => ({ key: 'value', amount })
+          ],
+          DECREMENT: amount => ({ amount: -amount })
+        },
+        NOTIFY: [
+          (username, message) => ({ message: `${username}: ${message}` }),
+          (username, message) => ({ username, message })
+        ]
+      }
+    }, { namespace: ':' });
+
+    // note: we should be using combineReducers in production, but this is just a test
+    const reducer = handleActions({
+      [combineActions(increment, decrement)]: ({ counter, message }, { payload: { amount } }) => ({
+        counter: counter + amount,
+        message
+      }),
+
+      APP: {
+        NOTIFY: {
+          next: ({ counter, message }, { payload }) => ({
+            counter,
+            message: `${message}---${payload.message}`
+          }),
+          throw: ({ counter, message }, { payload }) => ({
+            counter: 0,
+            message: `${message}-x-${payload.message}`
+          })
+        }
+      }
+    }, { counter: 0, message: '' }, { namespace: ':' });
+
+    expect(String(increment)).to.equal('APP:COUNTER:INCREMENT');
+
+    expect(reducer({ counter: 3, message: 'hello' }, increment(2))).to.deep.equal({
+      counter: 5,
+      message: 'hello'
+    });
+    expect(reducer({ counter: 10, message: 'hello' }, decrement(3))).to.deep.equal({
+      counter: 7,
+      message: 'hello'
+    });
+    expect(reducer({ counter: 10, message: 'hello' }, notify('me', 'goodbye'))).to.deep.equal({
+      counter: 10,
+      message: 'hello---me: goodbye'
+    });
+
+    const error = new Error('no notification');
+    expect(reducer({ counter: 10, message: 'hello' }, notify(error))).to.deep.equal({
+      counter: 0,
+      message: 'hello-x-no notification'
+    });
+  });
+
   it('should work with nested reducerMap and identity handlers', () => {
     const noop = createAction('APP/NOOP');
     const increment = createAction('APP/INCREMENT');

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -5,12 +5,12 @@ import handleAction from './handleAction';
 import ownKeys from './ownKeys';
 import { flattenReducerMap } from './namespaceActions';
 
-export default function handleActions(handlers, defaultState) {
+export default function handleActions(handlers, defaultState, { namespace } = {}) {
   invariant(
     isPlainObject(handlers),
     'Expected handlers to be an plain object.'
   );
-  const flattenedReducerMap = flattenReducerMap(handlers);
+  const flattenedReducerMap = flattenReducerMap(handlers, namespace);
   const reducers = ownKeys(flattenedReducerMap).map(type =>
     handleAction(
       type,

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -10,11 +10,11 @@ export default function handleActions(handlers, defaultState) {
     isPlainObject(handlers),
     'Expected handlers to be an plain object.'
   );
-  const flatHandlers = flattenReducerMap(handlers);
-  const reducers = ownKeys(flatHandlers).map(type =>
+  const flattenedReducerMap = flattenReducerMap(handlers);
+  const reducers = ownKeys(flattenedReducerMap).map(type =>
     handleAction(
       type,
-      flatHandlers[type],
+      flattenedReducerMap[type],
       defaultState
     )
   );

--- a/src/handleActions.js
+++ b/src/handleActions.js
@@ -3,16 +3,18 @@ import reduceReducers from 'reduce-reducers';
 import invariant from 'invariant';
 import handleAction from './handleAction';
 import ownKeys from './ownKeys';
+import { flattenReducerMap } from './namespaceActions';
 
 export default function handleActions(handlers, defaultState) {
   invariant(
     isPlainObject(handlers),
     'Expected handlers to be an plain object.'
   );
-  const reducers = ownKeys(handlers).map(type =>
+  const flatHandlers = flattenReducerMap(handlers);
+  const reducers = ownKeys(flatHandlers).map(type =>
     handleAction(
       type,
-      handlers[type],
+      flatHandlers[type],
       defaultState
     )
   );

--- a/src/hasGeneratorInterface.js
+++ b/src/hasGeneratorInterface.js
@@ -1,0 +1,7 @@
+import ownKeys from './ownKeys';
+
+export default function hasGeneratorInterface(handler) {
+  const keys = ownKeys(handler);
+  const hasOnlyInterfaceNames = keys.every((ownKey) => ownKey === 'next' || ownKey === 'throw');
+  return (keys.length && keys.length <= 2 && hasOnlyInterfaceNames);
+}

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -32,7 +32,9 @@ const flattenWhenNode = predicate => function flatten(
 };
 
 const flattenActionMap = flattenWhenNode(isPlainObject);
-const flattenReducerMap = flattenWhenNode(node => isPlainObject(node) && !hasGeneratorInterface(node));
+const flattenReducerMap = flattenWhenNode(
+  node => isPlainObject(node) && !hasGeneratorInterface(node)
+);
 
 function unflattenActionCreators(flatActionCreators, namespace = defaultNamespace) {
   function unflatten(

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -1,16 +1,9 @@
 import camelCase from './camelCase';
 import ownKeys from './ownKeys';
+import hasGeneratorInterface from './hasGeneratorInterface';
 import isPlainObject from 'lodash/isPlainObject';
-import includes from 'lodash/includes';
 
 const defaultNamespace = '/';
-
-function hasGeneratorInterface(handler) {
-  const generatorFnNames = ['next', 'throw'];
-  const keys = Object.getOwnPropertyNames(handler);
-  const onlyInterfaceFns = keys.every((fnName) => includes(generatorFnNames, fnName));
-  return (keys.length && keys.length <= 2 && onlyInterfaceFns);
-}
 
 const flattenBy = (predicate) =>
 function flatten(
@@ -39,7 +32,7 @@ function flatten(
   return partialFlatMap;
 };
 
-const flattenActionMap = flattenBy((node) => isPlainObject(node));
+const flattenActionMap = flattenBy(isPlainObject);
 const flattenReducerMap = flattenBy((node) => isPlainObject(node) && !hasGeneratorInterface(node));
 
 function unflattenActionCreators(flatActionCreators, namespace = defaultNamespace) {

--- a/src/namespaceActions.js
+++ b/src/namespaceActions.js
@@ -5,8 +5,7 @@ import isPlainObject from 'lodash/isPlainObject';
 
 const defaultNamespace = '/';
 
-const flattenBy = (predicate) =>
-function flatten(
+const flattenWhenNode = predicate => function flatten(
   map,
   namespace = defaultNamespace,
   partialFlatMap = {},
@@ -32,8 +31,8 @@ function flatten(
   return partialFlatMap;
 };
 
-const flattenActionMap = flattenBy(isPlainObject);
-const flattenReducerMap = flattenBy((node) => isPlainObject(node) && !hasGeneratorInterface(node));
+const flattenActionMap = flattenWhenNode(isPlainObject);
+const flattenReducerMap = flattenWhenNode(node => isPlainObject(node) && !hasGeneratorInterface(node));
 
 function unflattenActionCreators(flatActionCreators, namespace = defaultNamespace) {
   function unflatten(


### PR DESCRIPTION
Fixes #215 

Introduces `flattenReducerMap` with same behavior as `flattenActionMap` - except a guard, so that generator alike `{ next, throw }` objects are treated as a reducer.

As a side-note I would recommend to distinguish between `reducerMap` for a single reducer (the generator alike interface in `handleAction`) and a namespaced `reducerMap` in `handleActions`.
Can't come up with something better than `reducerObject` / `namedReducers` myself though.