### PR TITLE
Support that when reducer in actionMap is undefined or null, set it to identity function

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ const actionCreators = createActions({
         amount => ({ key: 'value', amount })
       ],
       DECREMENT: amount => ({ amount: -amount }),
-      SET: undefined
+      SET: undefined // given undefined, the identity function will be used
     },
     NOTIFY: [
       (username, message) => ({ message: `${username}: ${message}` }),
@@ -167,9 +167,9 @@ expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
   type: 'APP/COUNTER/DECREMENT',
   payload: { amount: -1 }
 });
-expect(actionCreators.app.counter.set(8)).to.deep.equal({
+expect(actionCreators.app.counter.set(100)).to.deep.equal({
   type: 'APP/COUNTER/SET',
-  payload: 8
+  payload: 100
 });
 expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
   type: 'APP/NOTIFY',

--- a/README.md
+++ b/README.md
@@ -171,10 +171,6 @@ expect(actionCreators.app.counter.set(8)).to.deep.equal({
   type: 'APP/COUNTER/SET',
   payload: 8
 });
-expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
-  type: 'APP/COUNTER/DECREMENT',
-  payload: { amount: -1 }
-});
 expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
   type: 'APP/NOTIFY',
   payload: { message: 'yangmillstheory: Hello World' },

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ const actionCreators = createActions({
         amount => ({ amount }),
         amount => ({ key: 'value', amount })
       ],
-      DECREMENT: amount => ({ amount: -amount })
+      DECREMENT: amount => ({ amount: -amount }),
+      SET: undefined
     },
     NOTIFY: [
       (username, message) => ({ message: `${username}: ${message}` }),
@@ -161,6 +162,14 @@ expect(actionCreators.app.counter.increment(1)).to.deep.equal({
   type: 'APP/COUNTER/INCREMENT',
   payload: { amount: 1 },
   meta: { key: 'value', amount: 1 }
+});
+expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
+  type: 'APP/COUNTER/DECREMENT',
+  payload: { amount: -1 }
+});
+expect(actionCreators.app.counter.set(8)).to.deep.equal({
+  type: 'APP/COUNTER/SET',
+  payload: 8
 });
 expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
   type: 'APP/COUNTER/DECREMENT',

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -18,7 +18,7 @@ describe('createActions', () => {
       })
     ).to.throw(
       Error,
-      'Expected function, undefined, or array with payload and meta functions for ACTION_2'
+      'Expected function, undefined, null, or array with payload and meta functions for ACTION_2'
     );
   });
 
@@ -32,7 +32,7 @@ describe('createActions', () => {
       })
     ).to.throw(
       Error,
-      'Expected function, undefined, or array with payload and meta functions for ACTION_1'
+      'Expected function, undefined, null, or array with payload and meta functions for ACTION_1'
     );
 
     expect(
@@ -48,26 +48,7 @@ describe('createActions', () => {
       })
     ).to.throw(
       Error,
-      'Expected function, undefined, or array with payload and meta functions for ACTION_2'
-    );
-  });
-
-  it('should throw an error if the reducer value is undefined in object form', () => {
-    expect(
-      () => createActions({ ACTION_1: undefined }, 'ACTION_2')
-    ).to.throw(
-      Error,
-      'Expected function, undefined, or array with payload and meta functions for ACTION_1'
-    );
-
-    expect(
-      () => createActions({
-        ACTION_1: () => {},
-        ACTION_2: undefined
-      })
-    ).to.throw(
-      Error,
-      'Expected function, undefined, or array with payload and meta functions for ACTION_2'
+      'Expected function, undefined, null, or array with payload and meta functions for ACTION_2'
     );
   });
 
@@ -78,7 +59,7 @@ describe('createActions', () => {
       })
     ).to.throw(
       Error,
-      'Expected function, undefined, or array with payload and meta functions for ACTION_1'
+      'Expected function, undefined, null, or array with payload and meta functions for ACTION_1'
     );
   });
 
@@ -211,7 +192,8 @@ describe('createActions', () => {
       APP: {
         COUNTER: {
           INCREMENT: amount => ({ amount }),
-          DECREMENT: amount => ({ amount: -amount })
+          DECREMENT: amount => ({ amount: -amount }),
+          SET: undefined
         },
         NOTIFY: (username, message) => ({ message: `${username}: ${message}` })
       },
@@ -225,6 +207,10 @@ describe('createActions', () => {
     expect(actionCreators.app.counter.decrement(1)).to.deep.equal({
       type: 'APP/COUNTER/DECREMENT',
       payload: { amount: -1 }
+    });
+    expect(actionCreators.app.counter.set(8)).to.deep.equal({
+      type: 'APP/COUNTER/SET',
+      payload: 8
     });
     expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
       type: 'APP/NOTIFY',

--- a/src/__tests__/createActions-test.js
+++ b/src/__tests__/createActions-test.js
@@ -208,9 +208,9 @@ describe('createActions', () => {
       type: 'APP/COUNTER/DECREMENT',
       payload: { amount: -1 }
     });
-    expect(actionCreators.app.counter.set(8)).to.deep.equal({
+    expect(actionCreators.app.counter.set(100)).to.deep.equal({
       type: 'APP/COUNTER/SET',
-      payload: 8
+      payload: 100
     });
     expect(actionCreators.app.notify('yangmillstheory', 'Hello World')).to.deep.equal({
       type: 'APP/NOTIFY',

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -6,8 +6,7 @@ import last from 'lodash/last';
 import isString from 'lodash/isString';
 import defaults from 'lodash/defaults';
 import isFunction from 'lodash/isFunction';
-import isUndefined from 'lodash/isUndefined';
-import isNull from 'lodash/isNull';
+import isNil from 'lodash/isNil';
 import createAction from './createAction';
 import invariant from 'invariant';
 import arrayToObject from './arrayToObject';
@@ -47,7 +46,7 @@ function actionCreatorsFromActionMap(actionMap, namespace) {
 
 function actionMapToActionCreators(actionMap) {
   function isValidActionMapValue(actionMapValue) {
-    if (isFunction(actionMapValue) || isUndefined(actionMapValue) || isNull(actionMapValue)) {
+    if (isFunction(actionMapValue) || isNil(actionMapValue)) {
       return true;
     } else if (isArray(actionMapValue)) {
       const [payload = identity, meta] = actionMapValue;

--- a/src/createActions.js
+++ b/src/createActions.js
@@ -6,6 +6,8 @@ import last from 'lodash/last';
 import isString from 'lodash/isString';
 import defaults from 'lodash/defaults';
 import isFunction from 'lodash/isFunction';
+import isUndefined from 'lodash/isUndefined';
+import isNull from 'lodash/isNull';
 import createAction from './createAction';
 import invariant from 'invariant';
 import arrayToObject from './arrayToObject';
@@ -45,7 +47,7 @@ function actionCreatorsFromActionMap(actionMap, namespace) {
 
 function actionMapToActionCreators(actionMap) {
   function isValidActionMapValue(actionMapValue) {
-    if (isFunction(actionMapValue)) {
+    if (isFunction(actionMapValue) || isUndefined(actionMapValue) || isNull(actionMapValue)) {
       return true;
     } else if (isArray(actionMapValue)) {
       const [payload = identity, meta] = actionMapValue;
@@ -58,7 +60,7 @@ function actionMapToActionCreators(actionMap) {
     const actionMapValue = actionMap[type];
     invariant(
       isValidActionMapValue(actionMapValue),
-      'Expected function, undefined, or array with payload and meta ' +
+      'Expected function, undefined, null, or array with payload and meta ' +
       `functions for ${type}`
     );
     const actionCreator = isArray(actionMapValue)


### PR DESCRIPTION
Support that when reducer in actionMap is undefined or null, set it to identity function