### PR TITLE
Pass shorthand arguments to reducers

### DIFF
--- a/docs/api/handleAction.md
+++ b/docs/api/handleAction.md
@@ -29,13 +29,24 @@ import { handleAction } from 'redux-actions';
 
 If a `reducer` function is passed, it is used to handle both normal actions and failed actions. (A failed action is analogous to a rejected promise.) You can use this form if you know a certain type of action will never fail, like the increment example above.
 
+The reducer function gets recieves the following arguments
+
+1. `state`: The current redux state
+
+1. `action`: The redux action
+	
+ and as a shorthand, for easier desctructuring:
+3. `payload`: The fsa payload of the action, *action.payload*
+4. `meta`: The metadata of the action, *action.meta*
+5. `error`: Boolean flag determining if this is an error, *action.error*
+
 If the reducer argument (`reducer`) is `undefined`, then the identity function is used.
 
 The third parameter `defaultState` is required, and is used when `undefined` is passed to the reducer.
 
 ###### EXAMPLE
 ```js
-handleAction('APP/COUNTER/INCREMENT', (state, action) => ({
+handleAction('APP/COUNTER/INCREMENT', (state, action, payload, meta, error) => ({
   counter: state.counter + action.payload.amount,
 }), defaultState);
 ```

--- a/src/__tests__/handleAction-test.js
+++ b/src/__tests__/handleAction-test.js
@@ -252,4 +252,23 @@ describe('handleAction()', () => {
         .to.deep.equal({ number: 3 });
     });
   });
+
+  describe('with shorthand arguments', () => {
+    it('recieves shorthand arguments', () => {
+      const reducer = handleAction(
+        type,
+        (state, action, payloadArg, metaArg, errorArg) =>
+          ({ ...state, payloadArg, metaArg, errorArg }),
+        prevState,
+      );
+
+      const error = new Error();
+      expect(reducer(prevState, { type, payload: 123 }))
+        .to.deep.equal({ ...prevState, payloadArg: 123, metaArg: undefined, errorArg: false });
+      expect(reducer(prevState, { type, payload: 123, meta: 456 }))
+        .to.deep.equal({ ...prevState, payloadArg: 123, metaArg: 456, errorArg: false });
+      expect(reducer(prevState, { type, payload: error, meta: 456, error: true }))
+        .to.deep.equal({ ...prevState, payloadArg: error, metaArg: 456, errorArg: true });
+    });
+  });
 });

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -28,6 +28,12 @@ export default function handleAction(type, reducer = identity, defaultState) {
       return state;
     }
 
-    return (action.error === true ? throwReducer : nextReducer)(state, action);
+    return (action.error === true ? throwReducer : nextReducer)(
+      state,
+      action,
+      action.payload,
+      action.meta,
+      action.error === true
+    );
   };
 }


### PR DESCRIPTION
Right now, in order to access the fsa properties you either have to use the the action argument directly or use destructuring:

```js
handleActions({
  ACTION: (state, action ) => {
    return { ...state, data: action.payload.data, user: action.meta.user }
  },
  DESTRUCTURING: (state, { payload: { data }, meta: { user } }) => {
    return { ...state, filters, data, user }
  },
})
```

I'm proposing a third backward compatible form, that simplifies destructuring for the most common cases and I think looks pleasing and simpler, and makes it obvious those should 
be the only properties of an fsa action

```js
handleActions({
  SHORT_HAND_ARGS: (state, action, payload, meta, error ) => {
    return { ...state, data:payload.data, user: meta.user }
  },
  SHORT_HAND_DESTRUCTURING: (state, action, { data }, { meta }, error) => {
    return { ...state, filters, data, user }
  },
})
```

