### PR TITLE
fix: add default field to exports in package.json for better compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "module": "./dist/redux-actions.js",
   "exports": {
     ".": {
-      "import": "./dist/redux-actions.js"
+      "import": "./dist/redux-actions.js",
+      "default": "./dist/redux-actions.js"
     }
   },
   "keywords": [


### PR DESCRIPTION
Add default field to exports in package.json for better compatibility.
Jest will be able to load the module and execute the transform.
fix #399
fix #390